### PR TITLE
Add status attribute in preparation to its use

### DIFF
--- a/lib/Statocles/Document.pm
+++ b/lib/Statocles/Document.pm
@@ -61,6 +61,21 @@ has author => (
     isa => Str,
 );
 
+=attr status
+
+The publishing status of this document.  Optional. Statocles apps can
+examine this to determine whether to turn a document into a page.  The
+default value is C<published>; other reasonable values could include
+C<draft> or C<private>.
+
+=cut
+
+has status => (
+    is => 'rw',
+    isa => Str,
+    default => 'published',
+);
+
 =attr content
 
 The raw content of this document, in markdown. This is everything below

--- a/t/document.t
+++ b/t/document.t
@@ -4,6 +4,15 @@ use Statocles::Document;
 
 my %default = ();
 
+subtest 'status' => sub {
+    my $doc = Statocles::Document->new(
+        %default,
+    );
+
+    is $doc->status => 'published';
+
+};
+
 subtest 'images' => sub {
     my $doc = Statocles::Document->new(
         %default,

--- a/t/share/store/write/doc_obj.markdown
+++ b/t/share/store/write/doc_obj.markdown
@@ -1,5 +1,6 @@
 ---
 date: 2014-06-05 00:00:00
+status: published
 tags:
     - one
     - two and three


### PR DESCRIPTION
As per IRC discussion with preaction, in preparation for migration scripts and more general workflow addons: added a status attribute and accompanying test.