### PR TITLE
Add standard frontmatter tags to blog post command

### DIFF
--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -159,12 +159,15 @@ sub command {
     }
     elsif ( $argv[0] eq 'post' ) {
         my %opt;
+        my @doc_opts = qw(author layout status tags template);
         GetOptionsFromArray( \@argv, \%opt,
             'date:s',
+            map { "$_:s" } @doc_opts,
         );
 
         my %doc = (
             %$default_post,
+            (map { defined $opt{$_} ? ( $_, $opt{$_} ) : () } @doc_opts),
             title => join " ", @argv[1..$#argv],
         );
 

--- a/t/app/blog/command.t
+++ b/t/app/blog/command.t
@@ -235,6 +235,57 @@ ENDMARKDOWN
                 };
             };
 
+            subtest 'author option' => sub {
+                local $ENV{EDITOR}; # We can't very well open vim...
+
+                my ( undef, undef, undef, $day, $mon, $year ) = localtime;
+                my $doc_path = $tmpdir->child(
+                    'blog',
+                    sprintf( '%04i', $year + 1900 ),
+                    sprintf( '%02i', $mon + 1 ),
+                    sprintf( '%02i', $day ),
+                    'this-is-a-title-for-stdin',
+                    'index.markdown',
+                );
+
+                subtest 'run the command' => sub {
+                    diag -t *STDIN
+                        ? "Before test: STDIN is interactive"
+                        : "Before test: STDIN is not interactive";
+
+                    open my $stdin, '<', \"This is content from STDIN\n";
+                    local *STDIN = $stdin;
+
+                    my @args = qw( blog post --author iasimov This is a Title for stdin );
+                    my ( $out, $err, $exit ) = capture { $app->command( @args ) };
+                    ok !$err, 'nothing on stdout' or diag $err;
+                    is $exit, 0;
+                    like $out, qr{New post at: \Q$doc_path},
+                        'contains blog post document path';
+
+                    if ( -e '/dev/tty' ) {
+                        diag -t *STDIN
+                            ? "After test: STDIN is interactive"
+                            : "After Test: STDIN is not interactive";
+                    }
+                };
+
+                subtest 'check the generated document' => sub {
+                    my $path = $doc_path->relative( $tmpdir->child('blog') );
+                    my $doc = $app->store->read_document( $path );
+                    cmp_deeply $doc, Statocles::Document->new(
+                        path => $path,
+                        title => 'This is a Title for stdin',
+                        author => 'iasimov',
+                        tags => undef,
+                        content => <<'ENDMARKDOWN',
+This is content from STDIN
+ENDMARKDOWN
+                        store => $app->store,
+                    );
+                };
+            };
+
             subtest 'with frontmatter' => sub {
                 local $ENV{EDITOR}; # We can't very well open vim...
 


### PR DESCRIPTION
Permit the simple frontmatter tags (author layout status tags template) from the blog post command:

    $ statocles blog post --author iasimov --tags mars,asteroid,mystery Marooned Off Vesta
