### PR TITLE
Fix Git->deploy(--clean) broken sprintf

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,3 +2,4 @@ Doug Bell <preaction@cpan.org> <madcityzen@gmail.com>
 Doug Bell <preaction@cpan.org> <preaction@users.noreply.github.com>
 Doug Bell <preaction@cpan.org> <doug.bell@baml.com>
 tadegenban <tadegenban@gmail.com> <youyouken@126.com>
+Kent Fredric <kentnl@cpan.org> <kentfredric@gmail.com>

--- a/lib/Statocles/Deploy/Git.pm
+++ b/lib/Statocles/Deploy/Git.pm
@@ -97,7 +97,7 @@ around 'deploy' => sub {
     }
 
     if ( $options{ clean } ) {
-        $self->site->log->info( sprintf 'Cleaning old content', $self->branch );
+        $self->site->log->info( sprintf 'Cleaning old content in branch "%s"', $self->branch );
         $self->_run( $git, 'rm', '-r', '-f', '.' );
         delete $options{ clean };
     }


### PR DESCRIPTION
Was previously calling:
```
sprintf FORMAT, VALUE
```
But format had no `%`, yielding the dreaded "extra arguments"
warning and the log output missing the intended branch.