### PR TITLE
Test cleanup

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ post_code_replacer = replace_with_nothing
 [PkgVersion]
 die_on_line_insertion = 1
 [CPANFile]
+[MetaJSON]
 [Git::Contributors]
 ; authordep Pod::Weaver::Section::Contributors
 [Test::ReportPrereqs]

--- a/lib/Statocles/Base.pm
+++ b/lib/Statocles/Base.pm
@@ -29,6 +29,7 @@ my @class_modules = (
 
 our %IMPORT_BUNDLES = (
     Test => [
+        sub { warn 'Bundle Test deprecated and will be removed in v1.000, do not use'; return },
         qw( Test::More Test::Deep Test::Differences Test::Exception ),
         'Dir::Self' => [qw( __DIR__ )],
         'Path::Tiny' => [qw( path tempdir cwd )],
@@ -71,7 +72,6 @@ __END__
 
     use Statocles::Base 'Class';
     use Statocles::Base 'Role';
-    use Statocles::Base 'Test';
 
 =head1 DESCRIPTION
 
@@ -137,34 +137,6 @@ The role bundle makes your package into a role and includes:
 =item L<Types::Path::Tiny> ':all'
 
 =item L<Statocles::Types> ':all'
-
-=back
-
-=head2 Test
-
-The test bundle includes:
-
-=over 4
-
-=item L<Test::More>
-
-=item L<Test::Deep>
-
-=item L<Test::Differences>
-
-=item L<Test::Exception>
-
-=item L<Dir::Self> '__DIR__'
-
-=item L<Path::Tiny> 'path', 'tempdir'
-
-=item L<Statocles::Test>
-
-Some common test routines for Statocles.
-
-=item L<Statocles::Site>
-
-In order to have logging, a site object must be created.
 
 =back
 

--- a/lib/Statocles/Test.pm
+++ b/lib/Statocles/Test.pm
@@ -106,32 +106,10 @@ sub build_test_site_apps {
     );
 }
 
-=sub test_constructor
-
-    test_constructor( $class, %args )
-
-Test an object constructor. C<class> is the class to test. C<args> is a list of
-name/value pairs with the following keys:
-
-=over 4
-
-=item required
-
-A set of name/value pairs for required arguments. These will be tested to ensure they
-are required. They will be added to every attempt to construct an object.
-
-=item default
-
-A set of name/value pairs for default arguments. These will be tested to ensure they
-are set to the correct defaults.
-
-=back
-
-=cut
 
 sub test_constructor {
     my ( $class, %args ) = @_;
-
+    warn 'Statocles::Test::test_constructor is deprecated and will be removed in v1.000';
     my %required = $args{required} ? ( %{ $args{required} } ) : ();
     my %defaults = $args{default} ? ( %{ $args{default} } ) : ();
     require Test::Builder;

--- a/lib/Statocles/Test.pm
+++ b/lib/Statocles/Test.pm
@@ -161,32 +161,9 @@ sub test_constructor {
     });
 }
 
-=sub test_pages
-
-    test_pages( $site, $app, %tests )
-
-Test the pages of the given app. C<tests> is a set of pairs of C<path> => C<callback>
-to test the pages returned by the app.
-
-The C<callback> will be given two arguments:
-
-=over
-
-=item C<output>
-
-The output of the rendered page.
-
-=item C<dom>
-
-If the page is HTML, a L<Mojo::DOM> object ready for testing.
-
-=back
-
-=cut
-
 sub test_pages {
     my ( $site, $app ) = ( shift, shift );
-
+    warn 'Statocles::Test::test_pages is deprecated and will be removed in v1.000';
     require Test::Builder;
 
     my %opt;

--- a/t/app/basic/command.t
+++ b/t/app/basic/command.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Statocles::App::Basic;
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/basic/constructor.t
+++ b/t/app/basic/constructor.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::App::Basic;
 
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/basic/pages.t
+++ b/t/app/basic/pages.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::App::Basic;
 
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/blog/command.t
+++ b/t/app/blog/command.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Statocles::App::Blog;
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/blog/constructor.t
+++ b/t/app/blog/constructor.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::App::Blog;
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );
 

--- a/t/app/blog/pages.t
+++ b/t/app/blog/pages.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use POSIX qw( locale_h );
 use Statocles::App::Blog;
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/blog/recent_posts.t
+++ b/t/app/blog/recent_posts.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::App::Blog;
 use Statocles::Page::Document;
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/events.t
+++ b/t/app/events.t
@@ -1,10 +1,10 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 my $site = build_test_site(
     theme => $SHARE_DIR->child( 'theme' ),
 );
-use Test::Lib;
 use TestApp;
 
 subtest build => sub {

--- a/t/app/perldoc/constructor.t
+++ b/t/app/perldoc/constructor.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::App::Perldoc;
 
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/perldoc/pages.t
+++ b/t/app/perldoc/pages.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::App::Perldoc;
 
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );

--- a/t/app/role/store.t
+++ b/t/app/role/store.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );
 
 {

--- a/t/app/template.t
+++ b/t/app/template.t
@@ -1,9 +1,9 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::App;
 use Statocles::App::Blog;
-use Test::Lib;
 use TestApp;
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );
 

--- a/t/app/url.t
+++ b/t/app/url.t
@@ -1,8 +1,8 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::App;
-use Test::Lib;
 use TestApp;
 
 my $site = Statocles::Site->new( deploy => tempdir );

--- a/t/bin/statocles.t
+++ b/t/bin/statocles.t
@@ -2,8 +2,8 @@
 # This test file duplicates some tests in t/command.t to ensure that
 # the bin/statocles frontend's delegation to Statocles::Command
 # works.
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $BIN = path( __DIR__, '..', '..', 'bin', 'statocles' );
 use Capture::Tiny qw( capture );
 

--- a/t/command/apps.t
+++ b/t/command/apps.t
@@ -1,8 +1,8 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Statocles::Command;
-use Test::Lib;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 
 subtest 'get the app list' => sub {

--- a/t/command/build_and_deploy.t
+++ b/t/command/build_and_deploy.t
@@ -1,9 +1,9 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Statocles::Command;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
-use Test::Lib;
 
 sub test_site {
     my ( $root, @args ) = @_;

--- a/t/command/bundle.t
+++ b/t/command/bundle.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Statocles::Command;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );

--- a/t/command/create.t
+++ b/t/command/create.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 use Statocles::Command;
 use Capture::Tiny qw( capture );

--- a/t/command/daemon.t
+++ b/t/command/daemon.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Mojo::IOLoop;
 use Statocles::Command;

--- a/t/command/error.t
+++ b/t/command/error.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use FindBin ();
 use Statocles::Command;

--- a/t/command/help_and_version.t
+++ b/t/command/help_and_version.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use FindBin ();
 use Statocles::Command;

--- a/t/command/mojo_app.t
+++ b/t/command/mojo_app.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Mojo::IOLoop;
 use Test::Mojo;

--- a/t/deploy/file.t
+++ b/t/deploy/file.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Deploy::File;
 
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );

--- a/t/deploy/git.t
+++ b/t/deploy/git.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Deploy::Git;
 BEGIN {
     my $git_version = Statocles::Deploy::Git->_git_version;

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Capture::Tiny qw( capture );
 my $SHARE_DIR = path( __DIR__ )->child( 'share' );

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -173,4 +173,26 @@ subtest 'tzoffset shim' => sub {
     }
 };
 
+subtest 'Statocles::Base q[Test]' => sub {
+    require Statocles::Base;
+    if ( $Statocles::VERSION < 1 ) {
+      ok( exists $Statocles::Base::IMPORT_BUNDLES{Test}, 'Test Bundle defined' ) or return;
+      my @warnings;
+      local $SIG{__WARN__} = sub { push @warnings, @_ };
+      local $@;
+      my $ok;
+      eval {
+          package T::My::Mock::Namespace;
+          Statocles::Base->import('Test');
+          $ok = 1;
+      };
+      ok( $ok, 'Importing Test did not fail' ) or  diag($@);
+      like $warnings[0], qr{\QBundle Test deprecated and will be removed in v1.000, do not use},
+        'Bundle test warns about deprecation';
+    }
+    else {
+     ok( !exists $Statocles::Base::IMPORT_BUNDLES{Test}, 'Test Bundle not defined' );
+    }
+};
+
 done_testing;

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -195,4 +195,20 @@ subtest 'Statocles::Base q[Test]' => sub {
     }
 };
 
+subtest 'Statocles::Test::test_constructor' => sub {
+    require Statocles::Test;
+    require Statocles::Link;
+    if ( $Statocles::VERSION < 1 ) {
+      my @warnings;
+      ok( Statocles::Test->can('test_constructor'), 'test_constructor function exists' ) or return;
+      local $SIG{__WARN__} = sub { push @warnings, @_ };
+      Statocles::Test::test_constructor('Statocles::Link', required => { href => '/blog' } );
+      like $warnings[0], qr{\QStatocles::Test::test_constructor is deprecated and will be removed in v1.000},
+        'warn on test_constructor function';
+    }
+    else {
+      ok( !Statocles::Test->can('test_constructor'), 'test_constructor function does not exist');
+    }
+};
+
 done_testing;

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -211,4 +211,37 @@ subtest 'Statocles::Test::test_constructor' => sub {
     }
 };
 
+subtest 'Statocles::Test::test_pages' => sub {
+    require Statocles::Test;
+    if ( $Statocles::VERSION < 1 ) {
+        my @warnings;
+        ok( Statocles::Test->can('test_pages'), 'test_pages function exists' )
+          or return;
+        local $@;
+        eval "
+        package Statocles::App::MockTest;
+        use Statocles::Base 'Class';
+        with 'Statocles::App';
+        sub pages { return () }
+        1
+      " or die "Cant construct a Statocles::App: $@";
+
+        my $site = build_test_site();
+
+        my $app = Statocles::App::MockTest->new( url_root => '/' );
+
+        local $SIG{__WARN__} = sub { push @warnings, @_ };
+        Statocles::Test::test_pages( $site, $app, {} );
+        like $warnings[0], qr{\QStatocles::Test::test_pages is deprecated and will be removed in v1.000},
+          'warn on test_constructor function';
+    }
+    else {
+        ok(
+            !Statocles::Test->can('test_pages'),
+            'test_pages function does not exist'
+        );
+    }
+};
+
+
 done_testing;

--- a/t/document.t
+++ b/t/document.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Document;
 
 my %default = ();

--- a/t/image.t
+++ b/t/image.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Image;
 
 subtest 'constructor' => sub {

--- a/t/lib/My/Test.pm
+++ b/t/lib/My/Test.pm
@@ -1,0 +1,35 @@
+package My::Test;
+
+# ABSTRACT: Utilities for testing Statocles Tests
+
+use strict;
+use warnings;
+use base 'Import::Base';
+
+our @IMPORT_MODULES = (
+    sub {
+        # Disable spurious warnings on platforms that Net::DNS::Native does not
+        # support. We don't use this much mojo
+        $ENV{MOJO_NO_NDN} = 1;
+        return;
+    },
+    strict => [],
+    warnings => [],
+    feature => [qw( :5.10 )],
+    'Path::Tiny' => [qw( rootdir cwd )],
+    'DateTime::Moonpig',
+    'Statocles',
+    qw( Test::More Test::Deep Test::Differences Test::Exception ),
+    'Dir::Self' => [qw( __DIR__ )],
+    'Path::Tiny' => [qw( path tempdir cwd )],
+    'Statocles::Test' => [qw(
+      test_constructor test_pages build_test_site build_test_site_apps
+      build_temp_site
+    )],
+    'Statocles::Types' => [qw( DateTimeObj )],
+    sub { $Statocles::VERSION ||= 0.001; return }, # Set version normally done via dzil
+);
+
+
+1;
+

--- a/t/lib/My/Test.pm
+++ b/t/lib/My/Test.pm
@@ -4,6 +4,7 @@ package My::Test;
 
 use strict;
 use warnings;
+
 use base 'Import::Base';
 
 our @IMPORT_MODULES = (
@@ -23,13 +24,88 @@ our @IMPORT_MODULES = (
     'Dir::Self' => [qw( __DIR__ )],
     'Path::Tiny' => [qw( path tempdir cwd )],
     'Statocles::Test' => [qw(
-      test_constructor test_pages build_test_site build_test_site_apps
+      test_pages build_test_site build_test_site_apps
       build_temp_site
     )],
     'Statocles::Types' => [qw( DateTimeObj )],
+    'My::Test::_Extras' => [qw( test_constructor )],
     sub { $Statocles::VERSION ||= 0.001; return }, # Set version normally done via dzil
 );
 
+package My::Test::_Extras;
 
+$INC{'My/Test/_Extras.pm'} = 1;
+
+require Exporter;
+*import = \&Exporter::import;
+
+our @EXPORT_OK = qw( test_constructor );
+
+sub test_constructor {
+    my ( $class, %args ) = @_;
+
+    my %required = $args{required} ? ( %{ $args{required} } ) : ();
+    my %defaults = $args{default}  ? ( %{ $args{default} } )  : ();
+    require Test::Builder;
+    require Scalar::Util;
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    my $tb = Test::Builder->new();
+
+    $tb->subtest(
+        $class . ' constructor' => sub {
+            my $got    = $class->new(%required);
+            my $want   = $class;
+            my $typeof = do {
+                    !defined $got                ? 'undefined'
+                  : !ref $got                    ? 'scalar'
+                  : !Scalar::Util::blessed($got) ? ref $got
+                  : eval { $got->isa($want) } ? $want
+                  :                             Scalar::Util::blessed($got);
+            };
+            $tb->is_eq( $typeof, $class,
+                'constructor works with all required args' );
+
+            if ( $args{required} ) {
+                $tb->subtest(
+                    'required attributes' => sub {
+                        for my $key ( keys %required ) {
+                            require Test::Exception;
+                            &Test::Exception::dies_ok(
+                                sub {
+                                    $class->new(
+                                        map { ; $_ => $required{$_} }
+                                        grep { $_ ne $key } keys %required,
+                                    );
+                                },
+                                $key . ' is required'
+                            );
+                        }
+                    }
+                );
+            }
+
+            if ( $args{default} ) {
+                $tb->subtest(
+                    'attribute defaults' => sub {
+                        my $obj = $class->new(%required);
+                        for my $key ( keys %defaults ) {
+                            if ( ref $defaults{$key} eq 'CODE' ) {
+                                local $_ = $obj->$key;
+                                $tb->subtest(
+                                    "$key default value" => $defaults{$key} );
+                            }
+                            else {
+                                require Test::Deep;
+                                Test::Deep::cmp_deeply( $obj->$key,
+                                    $defaults{$key}, "$key default value" );
+                            }
+                        }
+                    }
+                );
+            }
+
+        }
+    );
+}
 1;
-

--- a/t/link.t
+++ b/t/link.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Mojo::DOM;
 use Statocles::Link;
 

--- a/t/page/basename.t
+++ b/t/page/basename.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::Link;
 my $site = Statocles::Site->new( deploy => tempdir );

--- a/t/page/document.t
+++ b/t/page/document.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );
 
 use Statocles::Document;

--- a/t/page/file.t
+++ b/t/page/file.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );
 

--- a/t/page/images.t
+++ b/t/page/images.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::Image;
 my $site = Statocles::Site->new( deploy => tempdir );

--- a/t/page/links.t
+++ b/t/page/links.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::Link;
 my $site = Statocles::Site->new( deploy => tempdir );

--- a/t/page/list.t
+++ b/t/page/list.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::Page::Document;
 use Statocles::Document;

--- a/t/page/list_item.t
+++ b/t/page/list_item.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::Page::ListItem;
 use Statocles::Page::Document;

--- a/t/page/plain.t
+++ b/t/page/plain.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );
 

--- a/t/page/type.t
+++ b/t/page/type.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 my $site = Statocles::Site->new( deploy => tempdir );
 

--- a/t/plugin/highlight.t
+++ b/t/plugin/highlight.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 
 BEGIN {
     eval { require Syntax::Highlight::Engine::Kate; 1 } or plan skip_all => 'Syntax::Highlight::Engine::Kate needed';

--- a/t/plugin/html_lint.t
+++ b/t/plugin/html_lint.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 BEGIN {
     eval { require HTML::Lint::Pluggable; HTML::Lint::Pluggable->VERSION( 0.06 ); 1 } or plan skip_all => 'HTML::Lint::Pluggable v0.06 or higher needed';
 };

--- a/t/plugin/link_check.t
+++ b/t/plugin/link_check.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Mojo::Log;
 use Statocles::Plugin::LinkCheck;
 use Statocles::Image;

--- a/t/site/build_and_deploy.t
+++ b/t/site/build_and_deploy.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 

--- a/t/site/constructor.t
+++ b/t/site/constructor.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Site;
 use Statocles::Theme;
 use Statocles::Store;

--- a/t/site/data.t
+++ b/t/site/data.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 
 my ( $site, $build_dir, $deploy_dir ) = build_test_site_apps(

--- a/t/site/events.t
+++ b/t/site/events.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Page::Plain;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 

--- a/t/site/index.t
+++ b/t/site/index.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::App::Blog;
 use Mojo::DOM;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );

--- a/t/site/nav.t
+++ b/t/site/nav.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 
 my ( $site, $build_dir, $deploy_dir ) = build_test_site_apps(

--- a/t/site/plugin.t
+++ b/t/site/plugin.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 
 {

--- a/t/site/sitemap_and_robots.t
+++ b/t/site/sitemap_and_robots.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Mojo::DOM;
 use Statocles::App::Blog;
 use Statocles::App::Basic;

--- a/t/site/url.t
+++ b/t/site/url.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 
 subtest 'url method' => sub {

--- a/t/site/warnings.t
+++ b/t/site/warnings.t
@@ -1,12 +1,12 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Capture::Tiny qw( capture );
 use Statocles::Site;
 use Statocles::Page::Plain;
 use Statocles::Page::File;
 use Statocles::App::Basic;
 use Mojo::DOM;
-use Test::Lib;
 use TestApp;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 

--- a/t/store/constructor.t
+++ b/t/store/constructor.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Store;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 my $site = build_test_site( theme => $SHARE_DIR->child( 'theme' ) );

--- a/t/store/document.t
+++ b/t/store/document.t
@@ -1,9 +1,9 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Store;
 use Statocles::Util qw( dircopy );
 use Capture::Tiny qw( capture );
-use Test::Lib;
 use TestDocument;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 build_test_site( theme => $SHARE_DIR->child( 'theme' ) );

--- a/t/store/file.t
+++ b/t/store/file.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Store;
 use Capture::Tiny qw( capture );
 my $SHARE_DIR = path( __DIR__, '..', 'share' );

--- a/t/template/basic.t
+++ b/t/template/basic.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Template;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 build_test_site( theme => $SHARE_DIR->child( 'theme' ) );

--- a/t/template/include.t
+++ b/t/template/include.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Template;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 build_test_site( theme => $SHARE_DIR->child( 'theme' ) );

--- a/t/template/markdown.t
+++ b/t/template/markdown.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Template;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 my $site = build_test_site( theme => $SHARE_DIR->child( 'theme' ) );

--- a/t/theme/check.t
+++ b/t/theme/check.t
@@ -1,7 +1,7 @@
 
 # Check the syntax of all the built-in theme bundles
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 $Statocles::VERSION = '0.000001';
 use Statocles::Document;
 use Statocles::Page::List;

--- a/t/theme/helper.t
+++ b/t/theme/helper.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
 use Statocles::Theme;
 

--- a/t/theme/pages.t
+++ b/t/theme/pages.t
@@ -1,5 +1,6 @@
 
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Theme;
 
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );

--- a/t/theme/template.t
+++ b/t/theme/template.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Theme;
 use Statocles::Template;
 use Cwd qw( getcwd );

--- a/t/types.t
+++ b/t/types.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Types qw( Link LinkArray LinkHash DateTimeObj );
 
 subtest 'Link types' => sub {

--- a/t/util.t
+++ b/t/util.t
@@ -1,5 +1,5 @@
-
-use Statocles::Base 'Test';
+use Test::Lib;
+use My::Test;
 use Statocles::Util qw( dircopy run_editor uniq_by );
 use Statocles::Link;
 my $SHARE_DIR = path( __DIR__, 'share' );


### PR DESCRIPTION
Closes #468  by superseding it. 


<strike>I've left `test_pages` in place for now as it doesn't appear to use any of the "hot" dependencies, with the exception of `Test::More`</strike>

I attempted to use it myself somewhere, until I found it didn't work for me and it was easier to roll my own solution to that part, but I still have the import in place.

<strike>Will probably nuke that function in a later commit. </strike> Nuked.