### PR TITLE
Fixup README stuff

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,7 +24,11 @@ repository.type         = git
 -remove = Readme
 
 [Readme::Brief]
-[ReadmeMarkdownFromPod]
+[ReadmeAnyFromPod]
+location = build
+filename = README.mkdn
+type = markdown
+
 [PodWeaver]
 replacer = replace_with_comment
 post_code_replacer = replace_with_nothing

--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,7 @@ repository.type         = git
 -remove = GatherDir
 -remove = Readme
 
-[ReadmeFromPod]
+[Readme::Brief]
 [ReadmeMarkdownFromPod]
 [PodWeaver]
 replacer = replace_with_comment

--- a/dist.ini
+++ b/dist.ini
@@ -63,9 +63,6 @@ exclude_filename = Makefile.PL
 file_name = CHANGES
 show_author = 0
 
-[Run::AfterBuild]
-; Add travis and coveralls badges to README.mkdn
-run = perl -pi -e 's{(# SYNOPSIS)}{# STATUS\n\n<a href="https://travis-ci.org/preaction/Statocles"><img src="https://travis-ci.org/preaction/Statocles.svg?branch=master"></a><a href="https://coveralls.io/r/preaction/Statocles"><img src="https://coveralls.io/repos/preaction/Statocles/badge.png" alt="Coverage Status" /></a>\n\n$1}' %d/README.mkdn
 
 [CopyFilesFromBuild]
 ; Copy generated content to the repository root so users without Dist::Zilla
@@ -76,6 +73,10 @@ copy = LICENSE
 copy = CHANGES
 copy = README.mkdn
 copy = Makefile.PL
+
+[Run::AfterBuild]
+; Add travis and coveralls badges to README.mkdn
+run = perl -pi -e 's{(# SYNOPSIS)}{# STATUS\n\n<a href="https://travis-ci.org/preaction/Statocles"><img src="https://travis-ci.org/preaction/Statocles.svg?branch=master"></a><a href="https://coveralls.io/r/preaction/Statocles"><img src="https://coveralls.io/repos/preaction/Statocles/badge.png" alt="Coverage Status" /></a>\n\n$1}' README.mkdn
 
 ; --- Git management
 [Git::NextVersion]

--- a/dist.ini
+++ b/dist.ini
@@ -74,7 +74,6 @@ copy = cpanfile
 copy = INSTALL
 copy = LICENSE
 copy = CHANGES
-copy = README
 copy = README.mkdn
 copy = Makefile.PL
 

--- a/dist.ini
+++ b/dist.ini
@@ -21,6 +21,7 @@ repository.type         = git
 -bundle = @Basic
 ; GatherDir must be configured separately
 -remove = GatherDir
+-remove = Readme
 
 [ReadmeFromPod]
 [ReadmeMarkdownFromPod]

--- a/dist.ini
+++ b/dist.ini
@@ -25,7 +25,7 @@ repository.type         = git
 
 [Readme::Brief]
 [ReadmeAnyFromPod]
-location = build
+location = root
 filename = README.mkdn
 type = markdown
 
@@ -75,7 +75,6 @@ copy = cpanfile
 copy = INSTALL
 copy = LICENSE
 copy = CHANGES
-copy = README.mkdn
 copy = Makefile.PL
 
 [Run::AfterBuild]

--- a/weaver.ini
+++ b/weaver.ini
@@ -1,4 +1,5 @@
 [@CorePrep]
+[-SingleEncoding]
 
 [Name]
 [Version]


### PR DESCRIPTION
This is similar to the set of fixes I applied to Beam::Wire https://github.com/preaction/Beam-Wire/pull/61

The only significant difference is somehow, you had the known-broken ReadmeFromPod .... but it wasn't doing anything at all.

I can't tell you what it was doing, but the files it generated turned up neither in the source tree or the build.

At this point I'm kinda afraid to ask.

Either way, this is looking sexy: 

[README](https://github.com/preaction/Statocles/files/158019/README.txt)

I'm almost tempted to say that text rendition looks **better** than the page on MetaCPAN.