### PR TITLE
Rewrite Error message Address in use #485

### DIFF
--- a/lib/Statocles/Command.pm
+++ b/lib/Statocles/Command.pm
@@ -170,7 +170,12 @@ sub main {
         }
 
         # Using start() instead of run() so we can stop() inside the tests
-        $daemon->start;
+        eval {$daemon->start};
+        if ($@) {
+           my $port = $opt{port} ||$ENV{MOJO_LISTEN} || 3000;
+           $@ =~ s/socket:/socket on port $port:/;
+           die $@;
+        }
 
         # Find the port we're listening on
         my $id = $daemon->acceptors->[0];


### PR DESCRIPTION
"Can't create listen socket: Address already in use" is rewriten as
"Can't create listen socket on port $port: Address already in use"

Signed-off-by: Jose Luis Perez Diez <jluis@escomposlinux.org>