### PR TITLE
Improve slugs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -152,6 +152,7 @@ Path::Tiny = 0.084
 Types::Path::Tiny = 0
 List::UtilsBy = 0.09
 DateTime::Moonpig = 0
+Text::Unidecode = 0
 
 [Prereqs / Recommends]
 Pod::Weaver = 4.015

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -271,6 +271,7 @@ Given a post title, remove special characters to create a slug.
 sub make_slug {
     my ( $self, $slug ) = @_;
     $slug = unidecode($slug);
+    $slug =~ s/'//g;
     $slug =~ s/[\W]+/-/g;
     $slug =~ s/^-|-$//g;
     return lc $slug;

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -2,6 +2,7 @@ package Statocles::App::Blog;
 our $VERSION = '0.080';
 # ABSTRACT: A blog application
 
+use Text::Unidecode;
 use Statocles::Base 'Class';
 use Getopt::Long qw( GetOptionsFromArray );
 use Statocles::Store;
@@ -269,6 +270,7 @@ Given a post title, remove special characters to create a slug.
 
 sub make_slug {
     my ( $self, $slug ) = @_;
+    $slug = unidecode($slug);
     $slug =~ s/[\W]+/-/g;
     return lc $slug;
 }

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -272,6 +272,7 @@ sub make_slug {
     my ( $self, $slug ) = @_;
     $slug = unidecode($slug);
     $slug =~ s/[\W]+/-/g;
+    $slug =~ s/^-|-$//g;
     return lc $slug;
 }
 

--- a/t/app/blog/slugs.t
+++ b/t/app/blog/slugs.t
@@ -1,0 +1,45 @@
+use utf8;
+use Test::Lib;
+use My::Test;
+use Statocles::App::Blog;
+my $SHARE_DIR = path(__DIR__)->parent->parent->child('share');
+
+my $site = build_test_site( theme => $SHARE_DIR->child('theme'), );
+
+my $app = Statocles::App::Blog->new(
+    store    => $SHARE_DIR->child( 'app', 'blog' ),
+    url_root => '/blog',
+    site     => $site,
+);
+
+subtest 'slugs' => sub {
+    my $slug_tests = [
+        {
+            title       => q(El Niño),
+            slug        => q(el-nino),
+            description => q(non-ASCII character in title),
+        },
+        {
+            title       => q(How do I X?),
+            slug        => q(how-do-i-x),
+            description => q(trailing special character in title)
+        },
+        {
+            title       => q(¿cómo i x),
+            slug        => q(como-i-x),
+            description => q(leading special character in title)
+        },
+        {
+            title       => q(it's),
+            slug        => 'its',
+            description => q(apostrophe in title),
+        }
+    ];
+
+    foreach my $case ( @{$slug_tests} ) {
+        is( $app->make_slug( $case->{title} ),
+            $case->{slug}, $case->{description} );
+    }
+};
+
+done_testing;

--- a/t/theme/check.t
+++ b/t/theme/check.t
@@ -120,7 +120,7 @@ my %page = (
                 text => 'bar',
             ),
             Statocles::Link->new(
-                href => '/blog/tag/-baz-',
+                href => '/blog/tag/baz',
                 text => '<baz>',
             ),
         ],
@@ -484,7 +484,7 @@ my %content_tests = (
                         [qw(
                             http://example.com/blog/tag/foo
                             http://example.com/blog/tag/bar
-                            http://example.com/blog/tag/-baz-
+                            http://example.com/blog/tag/baz
                         )],
                         'tag link href is correct';
                 };
@@ -577,7 +577,7 @@ my %content_tests = (
                             [qw(
                                 http://example.com/blog/tag/foo
                                 http://example.com/blog/tag/bar
-                                http://example.com/blog/tag/-baz-
+                                http://example.com/blog/tag/baz
                             )],
                             'tag link href is correct';
                     };
@@ -627,7 +627,7 @@ my %content_tests = (
                     [ '<baz>', 'bar', 'foo' ],
                     'tag text is correct and sorted';
                 cmp_deeply [ $links->map( attr => 'href' )->each ],
-                    [ '/blog/tag/-baz-/', '/blog/tag/bar/', '/blog/tag/foo/' ],
+                    [ '/blog/tag/baz/', '/blog/tag/bar/', '/blog/tag/foo/' ],
                     'tag hrefs are correct and sorted';
             }
         };
@@ -692,7 +692,7 @@ my %content_tests = (
                     [ '<baz>', 'bar', 'foo' ],
                     'tag text is correct and sorted';
                 cmp_deeply [ $links->map( attr => 'href' )->each ],
-                    [ '/blog/tag/-baz-/', '/blog/tag/bar/', '/blog/tag/foo/', ],
+                    [ '/blog/tag/baz/', '/blog/tag/bar/', '/blog/tag/foo/', ],
                     'tag hrefs are correct and sorted';
             }
         };


### PR DESCRIPTION
This PR adds some basic tests for slug generation, and fixes two related issues. On top of that, it tries to convert non-ASCII characters in slugs too, and as a side-effect of removing the leading/trailing dashes from slugs, I had up update some tests.

I'm happy to rearrange and/or split the PR before merging if you prefer that, it just seemed like a good idea to keep these changes together. Feel free to let me know.

note: I found the instructions about where should I add myself as a contributor a bit confusing, so I left that out. I can send a followup commit or open a separate issue about that, but also feel free to add me wherever you think it fits :)