### PR TITLE
separate logic for obtaining list of files and filtering files so can modify the former

### DIFF
--- a/lib/Statocles/Store.pm
+++ b/lib/Statocles/Store.pm
@@ -324,6 +324,24 @@ sub has_file {
     return $self->path->child( $path )->is_file;
 }
 
+=method files
+
+    my $iter = $store->files
+
+Returns an iterator which iterates over I<all> files in the store,
+regardless of type of file.  The iterator returns a L<Path::Tiny>
+object or undef if no files remain.  It is used by L<find_files>.
+
+=cut
+
+sub files {
+
+    my ( $self ) = @_;
+
+    return $self->path->iterator({ recurse => 1 });
+}
+
+
 =method find_files
 
     my $iter = $store->find_files( %opt )
@@ -339,12 +357,14 @@ Available options are:
     include_documents      - If true, will include files that look like documents.
                              Defaults to false.
 
+It obtains its list of files from L<files>.
+
 =cut
 
 sub find_files {
     my ( $self, %opt ) = @_;
     $self->_check_exists;
-    my $iter = $self->path->iterator({ recurse => 1 });
+    my $iter = $self->files;
     return sub {
         my $path;
         while ( $path = $iter->() ) {

--- a/lib/Statocles/Store.pm
+++ b/lib/Statocles/Store.pm
@@ -335,9 +335,7 @@ object or undef if no files remain.  It is used by L<find_files>.
 =cut
 
 sub files {
-
     my ( $self ) = @_;
-
     return $self->path->iterator({ recurse => 1 });
 }
 


### PR DESCRIPTION
I'm implementing a store where the list of files is read from a manifest file.  I ended up copying `find_files` and modifying the definition of the iterator to

    my @manifest = $self->path->child('MANIFEST')->lines( { chomp => 1 } );
    my $iter = sub { return @manifest ? Path::Tiny::path(shift @manifest ) : undef }

Instead of duplicating `find_files`, it'd be cleaner to separate the generation of the original list of files from the filtering of the files.  That's what this PR does.  It adds a `files` method which returns an iterator.  With this, my code now looks like:
```
package StatoclesX::Role::Store::Manifest;
use Moo::Role;
around files => sub {
    my ( $orig, $self ) = @_;
    my @manifest = $self->path->child('MANIFEST')->lines( { chomp => 1 } );
    sub { return @manifest ? Path::Tiny::path(shift @manifest ) : undef }
};
1;
```
