### PR TITLE
Minor patch to silence a warning.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,12 @@ Changelog for Statocles
 
 {{ $NEXT }}
 
+    [Added]
+
+    - Added "blank" layout templates to the default and bootstrap
+      themes. These templates have no adornment whatsoever, and are
+      ideal for things like slide decks and pop-up windows.
+
 0.086     2017-09-13 22:22:32-05:00 America/Chicago
 
     [Added]

--- a/lib/Statocles/App/Perldoc.pm
+++ b/lib/Statocles/App/Perldoc.pm
@@ -251,7 +251,7 @@ sub _weave_module {
     # Pod::Weaver 4.014 shipped with a bug that causes problems unless
     # we have a LEGAL section, which we do not presently allow users to
     # set. So warn them to upgrade if they have this version
-    if ( $Pod::Weaver::VERSION == 4.014 ) {
+    if ( defined($Pod::Weaver::VERSION) and $Pod::Weaver::VERSION == 4.014 ) {
         $errors{ 'Pod::Weaver' } = q{Pod::Weaver version 4.014 has a bug that will cause a fatal error when a LEGAL section isn't available. Please upgrade to version 4.015 or later.};
     }
 
@@ -349,4 +349,3 @@ __END__
 This application generates HTML from the POD in the requested modules.
 
 =cut
-

--- a/share/theme/bootstrap/layout/blank.html.ep
+++ b/share/theme/bootstrap/layout/blank.html.ep
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+        <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
+        <link rel="stylesheet" href="/theme/css/statocles-bootstrap.css" />
+        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+        <title><%== $self->title ? $self->title . ' - ' : '' %><%== $site->title %></title>
+        % if ( my $author = $self->author ) {
+        <meta name="author" content="<%== $author->name %>">
+        % }
+        <meta name="generator" content="Statocles <%= $Statocles::VERSION %>" />
+        % for my $link ( $self->links( 'feed' ) ) {
+        <link rel="alternate" href="<%= $link->href %>" type="<%= $link->type %>" />
+        % }
+        % if ( my $img = $site->images->{ 'icon' } ) {
+        <link rel="shortcut icon" href="<%= $img->src %>" />
+        % }
+        %= include 'site/head_after.html.ep'
+        % for my $link ( $site->links( 'stylesheet' ) ) {
+        <link rel="stylesheet" href="<%= $link->href %>" type="<%= $link->type || 'text/css' %>" />
+        % }
+        % for my $link ( $self->links( 'stylesheet' ) ) {
+        <link rel="stylesheet" href="<%= $link->href %>" type="<%= $link->type || 'text/css' %>" />
+        % }
+        % for my $link ( $site->links( 'script' ) ) {
+        <script src="<%= $link->href %>"></script>
+        % }
+        % for my $link ( $self->links( 'script' ) ) {
+        <script src="<%= $link->href %>"></script>
+        % }
+    </head>
+    <body>
+        <main>
+            <%= content %>
+        </main>
+
+        % if ( $site->data->{google_analytics_id} ) {
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+          ga('create', '<%= $site->data->{google_analytics_id} %>', 'auto');
+          ga('send', 'pageview');
+        </script>
+        % }
+
+    </body>
+</html>

--- a/share/theme/default/layout/blank.html.ep
+++ b/share/theme/default/layout/blank.html.ep
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="/theme/css/normalize.css" />
+        <link rel="stylesheet" href="/theme/css/skeleton.css" />
+        <link rel="stylesheet" href="/theme/css/statocles-default.css" />
+        <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+        <title><%== $self->title ? $self->title . ' - ' : '' %><%== $site->title %></title>
+        % if ( my $author = $self->author ) {
+        <meta name="author" content="<%== $author->name %>">
+        % }
+        <meta name="generator" content="Statocles <%= $Statocles::VERSION %>" />
+        % for my $link ( $self->links( 'feed' ) ) {
+        <link rel="alternate" href="<%= $link->href %>" type="<%= $link->type %>" />
+        % }
+        % if ( my $img = $site->images->{ 'icon' } ) {
+        <link rel="shortcut icon" href="<%= $img->src %>" />
+        % }
+        %= include 'site/head_after.html.ep'
+        % for my $link ( $site->links( 'stylesheet' ) ) {
+        <link rel="stylesheet" href="<%= $link->href %>" type="<%= $link->type || 'text/css' %>" />
+        % }
+        % for my $link ( $self->links( 'stylesheet' ) ) {
+        <link rel="stylesheet" href="<%= $link->href %>" type="<%= $link->type || 'text/css' %>" />
+        % }
+        % for my $link ( $site->links( 'script' ) ) {
+        <script src="<%= $link->href %>"></script>
+        % }
+        % for my $link ( $self->links( 'script' ) ) {
+        <script src="<%= $link->href %>"></script>
+        % }
+    </head>
+    <body>
+        <main>
+            <%= content %>
+        </main>
+
+        % if ( $site->data->{google_analytics_id} ) {
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+          ga('create', '<%= $site->data->{google_analytics_id} %>', 'auto');
+          ga('send', 'pageview');
+        </script>
+        % }
+
+    </body>
+</html>


### PR DESCRIPTION
Avoid a `Use of uninitialized value` warning whilst checking installed version, when `Pod::Weaver` is not installed.