### PR TITLE
added next_page/prev_page attributes

### DIFF
--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -510,8 +510,8 @@ around pages => sub {
         my $page = $post_pages[$i];
         my $prev_page = $i ? $post_pages[$i-1] : undef;
         my $next_page = $post_pages[$i+1];
-        $page->prev( $prev_page->path ) if $prev_page;
-        $page->next( $next_page->path ) if $next_page;
+        $page->prev_page( $prev_page ) if $prev_page;
+        $page->next_page( $next_page ) if $next_page;
     }
 
     # Cache the post pages for this build

--- a/lib/Statocles/Page/Document.pm
+++ b/lib/Statocles/Page/Document.pm
@@ -274,17 +274,54 @@ around layout => sub {
 =attr next
 
 The path to the next document if it is part of a list.
+Defaults to the L<Statocles::Document/path> from L</next_page> if it exists.
+
+=cut
+
+has next => (
+    is => 'rw',
+    lazy => 1,
+    isa => Path|Undef,
+    coerce => Path->coercion,
+    default => sub { $_[0]->_page_path('next_page') },
+);
 
 =attr prev
 
 The path to the previous document if it is part of a list.
+Defaults to the L<Statocles::Document/path> from L</prev_page> if it exists.
 
 =cut
 
-has [qw( next prev )] => (
+has prev => (
     is => 'rw',
-    isa => Path,
+    lazy => 1,
+    isa => Path|Undef,
     coerce => Path->coercion,
+    default => sub { $_[0]->_page_path('prev_page') },
+);
+
+sub _page_path {
+  my ( $self, $method ) = @_;
+  if ( my $page = $self->$method() ) {
+    return $page->path;
+  }
+  return undef;
+}
+
+=attr next_page
+
+The L<Statocles::Page::Document> instance of the next document if it is part of a list.
+
+=attr prev_page
+
+The L<Statocles::Page::Document> instance of the previous document if it is part of a list.
+
+=cut
+
+has [qw( next_page prev_page )] => (
+    is => 'rw',
+    isa => InstanceOf['Statocles::Page::Document'],
 );
 
 1;


### PR DESCRIPTION
These are now set by the blog app rather than next/prev. Also made
next/prev use them to get their default values. As mentioned on IRC
next/prev could likely be deprecated. Note that there are no tests for
next_page/prev_page as yet (beyond any uses of the defaulting behavior
mentioned above).

While there are no new tests, there are existing tests that check that the blog app generates correct next/prev url links. As these are now generated via the next_page/prev_page there is at least some confirmation that it works.