### PR TITLE
allow LinkTree elements to be coerced from LinkArray definitions

### DIFF
--- a/lib/Statocles/Types.pm
+++ b/lib/Statocles/Types.pm
@@ -37,7 +37,7 @@ coerce Person, from Str, via { Statocles::Person->new( $_ ) };
 declare LinkArray, as ArrayRef[Link], coerce => 1;
 coerce LinkArray, from ArrayRef[HashRef|Str],
     via {
-        [ map { Link->coerce( $_ ) } @$_ ];
+        [ map { ref $_ eq 'HASH' && exists $_->{children} ? LinkTree->coerce($_) : Link->coerce( $_ ) } @$_ ];
     };
 
 declare LinkHash, as HashRef[LinkArray], coerce => 1;

--- a/t/types.t
+++ b/t/types.t
@@ -29,6 +29,16 @@ subtest 'Link types' => sub {
                     text => 'link two',
                     href => 'http://example.net',
                 },
+                {
+                    text => 'link three',
+                    href => 'http://example.org',
+                    children => [
+                        {
+                            text => 'link four',
+                            href => 'http://exmaple.co.uk'
+                        },
+                    ]
+                },
             ] );
 
             cmp_deeply $link_array, [
@@ -38,6 +48,16 @@ subtest 'Link types' => sub {
                 Statocles::Link->new(
                     text => 'link two',
                     href => 'http://example.net',
+                ),
+                Statocles::Link::Tree->new(
+                    text => 'link three',
+                    href => 'http://example.org',
+                    children => [
+                        Statocles::Link::Tree->new(
+                            text => 'link four',
+                            href => 'http://exmaple.co.uk'
+                        ),
+                    ],
                 ),
             ];
 


### PR DESCRIPTION
When trying to add children to a link inside of a navigation, the children aren't coerced. This is because the links in navigations are coerced down a chain to only Link object and not LinkTrees. In this coercion, if the input data is a hash reference and if has a key `children` then it is coerced to a LinkTree instead. This allows my template with nested navigation dropdowns to work as documented in your page http://preaction.me/statocles/docs/config