### PR TITLE
Don't rewrite anchor-only urls during index page rewrites

### DIFF
--- a/lib/Statocles/Site.pm
+++ b/lib/Statocles/Site.pm
@@ -648,8 +648,8 @@ sub build {
             for my $el ( $dom->find( "[$attr]" )->each ) {
                 my $url = $el->attr( $attr );
 
-                # Fix relative links on the index page
-                if ( $is_index && $index_orig_path && $url !~ m{^([A-Za-z]+:|/)} ) {
+                # Fix relative non-anchor links on the index page
+                if ( $is_index && $index_orig_path && $url !~ m{^([A-Za-z]+:|/|#)} ) {
                     $url = join "/", $index_orig_path->parent, $url;
                 }
 

--- a/t/share/app/basic/foo/other.markdown
+++ b/t/share/app/basic/foo/other.markdown
@@ -4,6 +4,7 @@ title: Foo Other
 
 * [Index](/index.html)
 * [Foo Index](index.html)
+* [Another Part](#another-part)
 
 # Foo Other
 
@@ -15,7 +16,7 @@ Vestibulum pellentesque risus et libero viverra mollis. Curabitur eu
 consectetur orci. Praesent massa metus, rutrum ac tortor quis, sagittis congue
 ex.
 
-## Another Part
+<h2 id="another-part">Another Part</h2>
 
 Aenean eu accumsan libero, sed sagittis ante. Sed pulvinar, nisi vitae egestas
 feugiat, metus magna congue ligula, vitae sollicitudin libero ante a enim.

--- a/t/site/index.t
+++ b/t/site/index.t
@@ -104,6 +104,8 @@ subtest 'index links in basic app' => sub {
             or diag explain [ $dom->find( '[href]' )->map( attr => 'href' )->each ];
         ok $dom->at( '[href=http://google.com]' ), 'full url is not touched'
             or diag explain [ $dom->find( '[href]' )->map( attr => 'href' )->each ];
+        ok $dom->at( '[href="#another-part"]' ), 'anchor url is not touched'
+            or diag explain [ $dom->find( '[href]' )->map( attr => 'href' )->each ];
     };
 
     subtest 'links to index page are correct' => sub {


### PR DESCRIPTION
When anchor-only hrefs are modified to point to some other page this
obviously breaks their intent to link to the current page.

Fixes #554