### PR TITLE
Fix some problems on Windows and when RE metacharacters in path

### DIFF
--- a/lib/Statocles/Util.pm
+++ b/lib/Statocles/Util.pm
@@ -65,7 +65,9 @@ sub run_editor {
     my ( $path ) = @_;
     return 0 unless $ENV{EDITOR};
     no warnings 'exec'; # We're checking everything ourselves
-    system split( /\s+/, $ENV{EDITOR} ), $path;
+    # use string "system" as env-vars need to quote to protect from spaces
+    # therefore, we quote path, then append it
+    system $ENV{EDITOR} . qq{ "$path"};
     if ($? == -1) {
         die sprintf qq{Failed to invoke editor "%s": %s\n}, $ENV{EDITOR}, $!;
     }

--- a/t/app/basic/command.t
+++ b/t/app/basic/command.t
@@ -1,4 +1,3 @@
-
 use Test::Lib;
 use My::Test;
 use Capture::Tiny qw( capture );
@@ -55,9 +54,8 @@ subtest 'edit' => sub {
     subtest 'create new page' => sub {
 
         subtest 'full path' => sub {
-            local $ENV{EDITOR} = "$^X " . $SHARE_DIR->child( 'bin', 'editor.pl' );
+            local $ENV{EDITOR} = join ' ', map qq{"$_"}, $^X, $SHARE_DIR->child( 'bin', 'editor.pl' );
             local $ENV{STATOCLES_TEST_EDITOR_CONTENT} = "".$SHARE_DIR->child(qw( app basic index.markdown ));
-
             my $doc_path = $tmpdir->child( "basic", "resume.markdown" );
 
             subtest 'run the command' => sub {

--- a/t/app/blog/command.t
+++ b/t/app/blog/command.t
@@ -347,7 +347,7 @@ ENDMARKDOWN
 
 
         subtest 'title change creates different folder' => sub {
-            local $ENV{EDITOR} = "$^X " . $SHARE_DIR->child( 'bin', 'editor.pl' );
+            local $ENV{EDITOR} = join ' ', map qq{"$_"}, $^X, $SHARE_DIR->child( 'bin', 'editor.pl' );
             local $ENV{STATOCLES_TEST_EDITOR_CONTENT} = "".$SHARE_DIR->child(qw( app blog draft a-draft-post.markdown ));
 
             my ( undef, undef, undef, $day, $mon, $year ) = localtime;

--- a/t/util.t
+++ b/t/util.t
@@ -4,6 +4,8 @@ use Statocles::Util qw( trim dircopy run_editor uniq_by derp );
 use Statocles::Link;
 my $SHARE_DIR = path( __DIR__, 'share' );
 
+use constant Win32 => $^O =~ /Win32/;
+
 subtest 'trim' => sub {
     my $foo;
     my @warnings;
@@ -77,13 +79,15 @@ subtest 'run_editor' => sub {
         } qr{Editor "HOPEFULLY_DOES_NOT_EXIST" exited with error \(non-zero\) status: .*\n};
     };
 
-    subtest 'editor dies by signal' => sub {
-        local $ENV{EDITOR} = $editor . " --signal TERM";
-        my $tmp = tempdir;
-        throws_ok {
-            run_editor( $tmp->child( 'index.markdown' ) );
-        } qr[Editor "\Q$ENV{EDITOR}\E" died from signal \d+\n];
-    };
+    if (!Win32) {
+        subtest 'editor dies by signal' => sub {
+            local $ENV{EDITOR} = $editor . " --signal TERM";
+            my $tmp = tempdir;
+            throws_ok {
+                run_editor( $tmp->child( 'index.markdown' ) );
+            } qr[Editor "\Q$ENV{EDITOR}\E" died from signal \d+\n];
+        };
+    }
 
     subtest 'editor nonzero exit' => sub {
         local $ENV{EDITOR} = $editor . " --exit 1";

--- a/t/util.t
+++ b/t/util.t
@@ -55,6 +55,7 @@ subtest 'dircopy' => sub {
 };
 
 subtest 'run_editor' => sub {
+    my $editor = join ' ', map qq{"$_"}, $^X, $SHARE_DIR->child( 'bin', 'editor.pl' );
     subtest 'no editor found' => sub {
         local $ENV{EDITOR};
         my $tmp = tempdir;
@@ -62,7 +63,7 @@ subtest 'run_editor' => sub {
     };
 
     subtest 'editor found' => sub {
-        local $ENV{EDITOR} = "$^X " . $SHARE_DIR->child( 'bin', 'editor.pl' );
+        local $ENV{EDITOR} = $editor;
         local $ENV{STATOCLES_TEST_EDITOR_CONTENT} = "".$SHARE_DIR->child(qw( app blog draft a-draft-post.markdown ));
         my $tmp = tempdir;
         ok run_editor( $tmp->child( 'index.markdown' ) ), 'editor invoked, so return true';
@@ -73,11 +74,11 @@ subtest 'run_editor' => sub {
         my $tmp = tempdir;
         throws_ok {
             run_editor( $tmp->child( 'index.markdown' ) );
-        } qr{Failed to invoke editor "HOPEFULLY_DOES_NOT_EXIST": .*\n};
+        } qr{Editor "HOPEFULLY_DOES_NOT_EXIST" exited with error \(non-zero\) status: .*\n};
     };
 
     subtest 'editor dies by signal' => sub {
-        local $ENV{EDITOR} = "$^X " . $SHARE_DIR->child( 'bin', 'editor.pl' ) . " --signal TERM";
+        local $ENV{EDITOR} = $editor . " --signal TERM";
         my $tmp = tempdir;
         throws_ok {
             run_editor( $tmp->child( 'index.markdown' ) );
@@ -85,7 +86,7 @@ subtest 'run_editor' => sub {
     };
 
     subtest 'editor nonzero exit' => sub {
-        local $ENV{EDITOR} = "$^X " . $SHARE_DIR->child( 'bin', 'editor.pl' ) . " --exit 1";
+        local $ENV{EDITOR} = $editor . " --exit 1";
         my $tmp = tempdir;
         throws_ok {
             run_editor( $tmp->child( 'index.markdown' ) );

--- a/t/util.t
+++ b/t/util.t
@@ -82,7 +82,7 @@ subtest 'run_editor' => sub {
         my $tmp = tempdir;
         throws_ok {
             run_editor( $tmp->child( 'index.markdown' ) );
-        } qr[Editor "$ENV{EDITOR}" died from signal \d+\n];
+        } qr[Editor "\Q$ENV{EDITOR}\E" died from signal \d+\n];
     };
 
     subtest 'editor nonzero exit' => sub {
@@ -90,7 +90,7 @@ subtest 'run_editor' => sub {
         my $tmp = tempdir;
         throws_ok {
             run_editor( $tmp->child( 'index.markdown' ) );
-        } qr[Editor "$ENV{EDITOR}" exited with error \(non-zero\) status: 1\n];
+        } qr[Editor "\Q$ENV{EDITOR}\E" exited with error \(non-zero\) status: 1\n];
     };
 };
 


### PR DESCRIPTION
The `lib/Statocles/Util.pm` change is so that it can handle when there are single entities in eg `$^X` that have spaces, instead of just doing a `split` on whitespace. To do it truly truly properly would probably require `Text::ParseWords` and I didn't want to add a dep.