### PR TITLE
Tweaks

### DIFF
--- a/lib/Statocles/App.pm
+++ b/lib/Statocles/App.pm
@@ -127,17 +127,18 @@ around pages => sub {
 
 =method url
 
-    my $app_url = $app->url( $path );
+    my $app_url = $app->url( $path[, $keep_index] );
 
 Get a URL to a page in this application. Prepends the app's L<url_root
-attribute|/url_root>. Strips "index.html" if possible.
+attribute|/url_root>. Strips "index.html" if C<$keep_index> is not given,
+or false. Avoids double-C</> in the result.
 
 =cut
 
 sub url {
-    my ( $self, $url ) = @_;
+    my ( $self, $url, $keep_index ) = @_;
     my $base = $self->url_root;
-    $url =~ s{/index[.]html$}{/};
+    $url =~ s{/index[.]html$}{/} unless $keep_index;
 
     # Remove the / from both sides of the join so we don't double up
     $base =~ s{/$}{};

--- a/lib/Statocles/App.pm
+++ b/lib/Statocles/App.pm
@@ -160,7 +160,7 @@ attribute|/url_root> is prepended, if necessary.
 sub link {
     my ( $self, %args ) = @_;
     my $url_root = $self->url_root;
-    if ( $args{href} !~ /^$url_root/ ) {
+    if ( index( $args{href}, $url_root ) != 0 ) {
         $args{href} = $self->url( $args{href} );
     }
     return Statocles::Link->new( %args );

--- a/lib/Statocles/App.pm
+++ b/lib/Statocles/App.pm
@@ -114,9 +114,9 @@ around pages => sub {
         }
 
         for my $attr ( @url_attrs ) {
-            if ( $page->$attr && $page->$attr !~ /^$url_root/ ) {
-                $page->$attr( join "/", $url_root, $page->$attr );
-            }
+            next unless my $value = $page->$attr;
+            next if index( $value, $url_root ) == 0;
+            $page->$attr( $self->url( $value, 1 ) );
         }
     }
 

--- a/lib/Statocles/App.pm
+++ b/lib/Statocles/App.pm
@@ -130,7 +130,7 @@ around pages => sub {
     my $app_url = $app->url( $path );
 
 Get a URL to a page in this application. Prepends the app's L<url_root
-attribute|/url_root> if necessary. Strips "index.html" if possible.
+attribute|/url_root>. Strips "index.html" if possible.
 
 =cut
 

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -356,7 +356,7 @@ sub index {
         push @feed_pages, $page;
         push @feed_links, $self->link(
             text => $FEEDS{ $feed }{ text },
-            href => $page->path->stringify,
+            href => $page->path.'',
             type => $page->type,
         );
     }
@@ -424,7 +424,7 @@ sub tag_pages {
             push @feed_pages, $page;
             push @feed_links, $self->link(
                 text => $FEEDS{ $feed }{ text },
-                href => $page->path->stringify,
+                href => $page->path.'',
                 type => $page->type,
             );
         }

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -323,8 +323,8 @@ sub index {
 
     my @pages = Statocles::Page::List->paginate(
         after => $self->page_size,
-        path => $self->url_root . '/page/%i/index.html',
-        index => $self->url_root . '/index.html',
+        path => $self->url( 'page/%i/index.html', 1 ),
+        index => $self->url( 'index.html' ),
         pages => [ _sort_page_list( @index_post_pages ) ],
         app => $self,
         template => $self->template( 'index.html' ),
@@ -340,7 +340,7 @@ sub index {
         my $page = Statocles::Page::List->new(
             app => $self,
             pages => $index->pages,
-            path => $self->url_root . '/index.' . $feed,
+            path => $self->url( 'index.' . $feed ),
             template => $self->template( $FEEDS{$feed}{template} ),
             links => {
                 alternate => [
@@ -384,10 +384,11 @@ sub tag_pages {
 
     my @pages;
     for my $tag ( keys %$tagged_docs ) {
+        my $tagroot = $self->url( join "/", 'tag', $self->_tag_url( $tag ) );
         my @tag_pages = Statocles::Page::List->paginate(
             after => $self->page_size,
-            path => join( "/", $self->url_root, 'tag', $self->_tag_url( $tag ), 'page/%i/index.html' ),
-            index => join( "/", $self->url_root, 'tag', $self->_tag_url( $tag ), 'index.html' ),
+            path => join( "/", $tagroot, 'page/%i/index.html' ),
+            index => join( "/", $tagroot, 'index.html' ),
             pages => [ _sort_page_list( @{ $tagged_docs->{ $tag } } ) ],
             app => $self,
             template => $self->template( 'index.html' ),
@@ -407,7 +408,7 @@ sub tag_pages {
             my $page = Statocles::Page::List->new(
                 app => $self,
                 pages => $index->pages,
-                path => join( "/", $self->url_root, 'tag', $tag_file ),
+                path => $self->url( join( "/", 'tag', $tag_file ) ),
                 template => $self->template( $FEEDS{$feed}{template} ),
                 links => {
                     alternate => [

--- a/lib/Statocles/Page.pm
+++ b/lib/Statocles/Page.pm
@@ -76,7 +76,9 @@ has type => (
     lazy => 1,
     default => sub {
         my ( $self ) = @_;
-        my ( $ext ) = $self->path =~ /[.]([^.]+)$/;
+        my $filename = (split '/', $self->path.'', -1)[-1];
+        return $TYPES{html} if $filename eq '';
+        my ( $ext ) = $filename =~ /[.]([^.]+)$/;
         return $TYPES{ $ext };
     },
 );

--- a/t/app/blog/pages.t
+++ b/t/app/blog/pages.t
@@ -914,7 +914,7 @@ subtest 'blog with two posts in the same day' => sub {
     );
     my @pages = $app->pages;
     my ( $index ) = grep { $_->path eq '/index.html' } @pages;
-    cmp_deeply [ map { $_->path->stringify } @{ $index->pages } ],
+    cmp_deeply [ map { $_->path.'' } @{ $index->pages } ],
         [qw( /2016/06/01/aaa-first/index.html /2016/06/01/zzz-last/index.html )],
         'index page is ordered correctly'
             or diag explain [
@@ -923,7 +923,7 @@ subtest 'blog with two posts in the same day' => sub {
             ];
 
     my ( $tag_page ) = grep { $_->path eq '/tag/mytag/index.html' } @pages;
-    cmp_deeply [ map { $_->path->stringify } @{ $tag_page->pages } ],
+    cmp_deeply [ map { $_->path.'' } @{ $tag_page->pages } ],
         [qw( /2016/06/01/aaa-first/index.html /2016/06/01/zzz-last/index.html )],
         'tag page is ordered correctly'
             or diag explain [

--- a/t/app/blog/recent_posts.t
+++ b/t/app/blog/recent_posts.t
@@ -17,30 +17,18 @@ my $app = Statocles::App::Blog->new(
 
 subtest 'recent_posts' => sub {
     my @pages = $app->recent_posts( 2 );
-    cmp_deeply [ @pages ], [
-        methods(
-            path => Path::Tiny->new(
-                qw{ blog 2014 06 02 more_tags index.html }
-            )->absolute( '/' ),
-        ),
-        methods(
-            path => Path::Tiny->new(
-                qw{ blog 2014 05 22 (regex)[name].file.html }
-            )->absolute( '/' ),
-        ),
-    ];
+    is_deeply [ map $_->path.'', @pages ], [
+        '/blog/2014/06/02/more_tags/index.html',
+        '/blog/2014/05/22/(regex)[name].file.html',
+    ] or diag explain [ map { $_->path } @pages ];
 };
 
 subtest 'posts with given tag' => sub {
 
     subtest 'single tag (not enough posts)' => sub {
         my @pages = $app->recent_posts( 2, tags => 'more' );
-        cmp_deeply \@pages, [
-            methods(
-                path => Path::Tiny->new(
-                    qw{ blog 2014 06 02 more_tags index.html }
-                )->absolute( '/' ),
-            ),
+        is_deeply [ map $_->path.'', @pages ], [
+            '/blog/2014/06/02/more_tags/index.html',
         ] or diag explain [ map { $_->path } @pages ];
     };
 

--- a/t/lib/My/Test.pm
+++ b/t/lib/My/Test.pm
@@ -185,7 +185,7 @@ sub test_pages {
             }
         }
 
-        if ( $page->path =~ /[.](?:html|rss|atom)$/ ) {
+        if ( $page->path =~ m#(?:/|[.](?:html|rss|atom))$# ) {
             require Mojo::DOM;
             my $dom = Mojo::DOM->new($output);
             $tb->ok( 0, "Could not parse dom" ) unless $dom;

--- a/t/lib/My/Test.pm
+++ b/t/lib/My/Test.pm
@@ -130,11 +130,24 @@ sub test_pages {
 
     my @pages = $app->pages;
 
-    $tb->is_eq(
-        scalar @pages,
-        scalar keys %page_tests,
-        'correct number of pages'
-    ) or $tb->diag( "Got: " . join( ", ", map { $_->path } @pages ) . "\n" . "Expect: " . join( ", ", keys %page_tests ) );
+    my %pages_app = map { ($_->path => 1) } @pages;
+    my %page_tests_copy = %page_tests;
+    delete @page_tests_copy{ keys %pages_app };
+    delete @pages_app{ keys %page_tests };
+
+    $tb->cmp_ok(
+        scalar(keys %pages_app),
+        '==',
+        0,
+        'No untested pages'
+    ) or $tb->diag( "Extra app pages: " . join( ", ", sort keys %pages_app ) );
+
+    $tb->cmp_ok(
+        scalar(keys %page_tests_copy),
+        '==',
+        0,
+        'No unpaged tests'
+    ) or $tb->diag( "Extra pages tested: " . join( ", ", sort keys %page_tests_copy ) );
 
     for my $page (@pages) {
         $tb->ok( $page->DOES('Statocles::Page'), 'must be a Statocles::Page' );


### PR DESCRIPTION
These are the independent changes I've felt necessary while fighting to separate the paths that are file-paths from paths that are parts of URLs :-)

Notably, I added a param to the App's `url` method to control it stripping off `index.html`. I thought that was worthwhile because of the useful extra-`/`-avoiding behaviour it has, which is important for `Mojo::Path` objects, while `Path::Tiny` just hides them.

I hope you also find the `test_pages` behaviour change useful - now if there are missing or extra pages it will tell you just which ones, not all of both.