### PR TITLE
Refactor roles

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -52,7 +52,7 @@ language](https://metacpan.org/pod/Mojo::Template#SYNTAX).
 - SEO-friendly features such as [sitemaps (sitemap.xml)](http://www.sitemaps.org).
 - [Automatic checking for broken links](https://metacpan.org/pod/Statocles::Plugin::LinkCheck).
 - [Syntax highlighting](https://metacpan.org/pod/Statocles::Plugin::Highlight) for code and configuration blocks.
-- Hooks to add [your own plugins](https://metacpan.org/pod/Statocles::Plugin) and [your own custom
+- Hooks to add [your own plugins](https://metacpan.org/pod/Statocles::Role::Plugin) and [your own custom
 applications](https://metacpan.org/pod/Statocles::Role::App).
 
 # ATTRIBUTES

--- a/README.mkdn
+++ b/README.mkdn
@@ -53,7 +53,7 @@ language](https://metacpan.org/pod/Mojo::Template#SYNTAX).
 - [Automatic checking for broken links](https://metacpan.org/pod/Statocles::Plugin::LinkCheck).
 - [Syntax highlighting](https://metacpan.org/pod/Statocles::Plugin::Highlight) for code and configuration blocks.
 - Hooks to add [your own plugins](https://metacpan.org/pod/Statocles::Plugin) and [your own custom
-applications](https://metacpan.org/pod/Statocles::App).
+applications](https://metacpan.org/pod/Statocles::Role::App).
 
 # ATTRIBUTES
 

--- a/lib/Statocles.pm
+++ b/lib/Statocles.pm
@@ -263,7 +263,7 @@ L<Syntax highlighting|Statocles::Plugin::Highlight> for code and configuration b
 
 =item *
 
-Hooks to add L<your own plugins|Statocles::Plugin> and L<your own custom
+Hooks to add L<your own plugins|Statocles::Role::Plugin> and L<your own custom
 applications|Statocles::Role::App>.
 
 =back

--- a/lib/Statocles.pm
+++ b/lib/Statocles.pm
@@ -264,7 +264,7 @@ L<Syntax highlighting|Statocles::Plugin::Highlight> for code and configuration b
 =item *
 
 Hooks to add L<your own plugins|Statocles::Plugin> and L<your own custom
-applications|Statocles::App>.
+applications|Statocles::Role::App>.
 
 =back
 

--- a/lib/Statocles/App/Basic.pm
+++ b/lib/Statocles/App/Basic.pm
@@ -5,7 +5,7 @@ our $VERSION = '0.094';
 use Statocles::Base 'Class';
 use Statocles::Document;
 use Statocles::Util qw( run_editor read_stdin );
-with 'Statocles::App::Role::Store';
+with 'Statocles::Role::App::Store';
 
 =attr store
 

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -10,7 +10,7 @@ use Statocles::Page::Document;
 use Statocles::Page::List;
 use Statocles::Util qw( run_editor read_stdin );
 
-with 'Statocles::App::Role::Store';
+with 'Statocles::Role::App::Store';
 
 =attr store
 

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -377,7 +377,7 @@ sub index {
 
     my @pages = $app->tag_pages( \%tag_pages );
 
-Get L<pages|Statocles::Page> for the tags in the given blog post documents
+Get L<pages|Statocles::Role::Page> for the tags in the given blog post documents
 (build from L<the post_pages method|/post_pages>, including relevant feed
 pages.
 
@@ -448,7 +448,7 @@ sub tag_pages {
 
     my @pages = $app->pages( %options );
 
-Get all the L<pages|Statocles::Page> for this application. Available options
+Get all the L<pages|Statocles::Role::Page> for this application. Available options
 are:
 
 =over 4
@@ -606,7 +606,7 @@ sub recent_posts {
 
     my $url = $app->page_url( $page )
 
-Return the absolute URL to this L<page object|Statocles::Page>, removing the
+Return the absolute URL to this L<page object|Statocles::Role::Page>, removing the
 "/index.html" if necessary.
 
 =cut

--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -760,7 +760,7 @@ The post author
 
 =over 4
 
-=item L<Statocles::App>
+=item L<Statocles::Role::App>
 
 =back
 

--- a/lib/Statocles/App/Perldoc.pm
+++ b/lib/Statocles/App/Perldoc.pm
@@ -7,7 +7,7 @@ use Statocles::Page::Plain;
 use Scalar::Util qw( blessed );
 use Pod::Simple::Search;
 use Pod::Simple::XHTML;
-with 'Statocles::App';
+with 'Statocles::Role::App';
 
 =attr inc
 

--- a/lib/Statocles/App/Perldoc.pm
+++ b/lib/Statocles/App/Perldoc.pm
@@ -92,7 +92,7 @@ has '+template_dir' => (
 
     my @pages = $app->pages;
 
-Render the requested modules as HTML. Returns an array of L<Statocles::Page> objects.
+Render the requested modules as HTML. Returns an array of L<Statocles::Role::Page> objects.
 
 =cut
 

--- a/lib/Statocles/App/Role/Store.pm
+++ b/lib/Statocles/App/Role/Store.pm
@@ -27,7 +27,7 @@ to use L<store objects|Statocles::Store> to manage content with Markdown files.
 use Statocles::Base 'Role';
 use Statocles::Page::Document;
 use Statocles::Page::File;
-with 'Statocles::App';
+with 'Statocles::Role::App';
 
 =attr store
 

--- a/lib/Statocles/App/Static.pm
+++ b/lib/Statocles/App/Static.pm
@@ -5,7 +5,7 @@ our $VERSION = '0.094';
 use Statocles::Base 'Class';
 use Statocles::Page::File;
 use Statocles::Util qw( derp );
-with 'Statocles::App';
+with 'Statocles::Role::App';
 
 =attr store
 
@@ -54,5 +54,5 @@ B<NOTE:> This application's functionality has been added to
 L<Statocles::App::Basic>. You can use the Basic app to replace this app. This
 class will be removed with v2.0. See L<Statocles::Help::Upgrading>.
 
-This L<Statocles::App|Statocles::App> manages static content with no processing,
+This L<Statocles::Role::App|Statocles::Role::App> manages static content with no processing,
 perfect for images, stylesheets, scripts, or already-built HTML.

--- a/lib/Statocles/App/Static.pm
+++ b/lib/Statocles/App/Static.pm
@@ -24,7 +24,7 @@ has store => (
 
     my @pages = $app->pages;
 
-Get the L<page objects|Statocles::Page> for this app.
+Get the L<page objects|Statocles::Role::Page> for this app.
 
 =cut
 

--- a/lib/Statocles/Deploy/File.pm
+++ b/lib/Statocles/Deploy/File.pm
@@ -3,7 +3,7 @@ our $VERSION = '0.094';
 # ABSTRACT: Deploy a site to a folder on the filesystem
 
 use Statocles::Base 'Class';
-with 'Statocles::Deploy';
+with 'Statocles::Role::Deploy';
 use Statocles::Util qw( dircopy );
 
 =attr path
@@ -60,13 +60,13 @@ __END__
 
 This class allows a site to be deployed to a folder on the filesystem.
 
-This class consumes L<Statocles::Deploy|Statocles::Deploy>.
+This class consumes L<Statocles::Role::Deploy|Statocles::Role::Deploy>.
 
 =head1 SEE ALSO
 
 =over 4
 
-=item L<Statocles::Deploy>
+=item L<Statocles::Role::Deploy>
 
 =back
 

--- a/lib/Statocles/Deploy/Git.pm
+++ b/lib/Statocles/Deploy/Git.pm
@@ -208,13 +208,13 @@ __END__
 
 This class allows a site to be deployed to a Git repository.
 
-This class consumes L<Statocles::Deploy|Statocles::Deploy>.
+This class consumes L<Statocles::Role::Deploy|Statocles::Role::Deploy>.
 
 =head1 SEE ALSO
 
 =over 4
 
-=item L<Statocles::Deploy>
+=item L<Statocles::Role::Deploy>
 
 =back
 

--- a/lib/Statocles/Document.pm
+++ b/lib/Statocles/Document.pm
@@ -462,7 +462,7 @@ __END__
 
 A Statocles::Document is the base unit of content in Statocles.
 L<Applications|Statocles::Role::App> take documents to build
-L<pages|Statocles::Page>.
+L<pages|Statocles::Role::Page>.
 
 Documents are usually written as files, with the L<content|/content> in Markdown,
 and the other attributes as frontmatter, a block of YAML at the top of the file.

--- a/lib/Statocles/Document.pm
+++ b/lib/Statocles/Document.pm
@@ -312,7 +312,7 @@ This disables processing the content as a template. This can speed up processing
 when the content is not using template directives. 
 
 This can be also set in the application
-(L<Statocles::App/disable_content_template>), or for the entire site
+(L<Statocles::Role::App/disable_content_template>), or for the entire site
 (L<Statocles::Site/disable_content_template>).
 
 =cut
@@ -461,7 +461,7 @@ __END__
 =head1 DESCRIPTION
 
 A Statocles::Document is the base unit of content in Statocles.
-L<Applications|Statocles::App> take documents to build
+L<Applications|Statocles::Role::App> take documents to build
 L<pages|Statocles::Page>.
 
 Documents are usually written as files, with the L<content|/content> in Markdown,

--- a/lib/Statocles/Event.pm
+++ b/lib/Statocles/Event.pm
@@ -17,13 +17,13 @@ extends 'Beam::Event';
 
 =attr pages
 
-An array of L<Statocles::Page> objects
+An array of L<Statocles::Role::Page> objects
 
 =cut
 
 has pages => (
     is => 'ro',
-    isa => ArrayRef[ConsumerOf['Statocles::Page']],
+    isa => ArrayRef[ConsumerOf['Statocles::Role::Page']],
     required => 1,
 );
 

--- a/lib/Statocles/Help.pod
+++ b/lib/Statocles/Help.pod
@@ -76,7 +76,7 @@ L<Statocles::Command> - Command module
 
 =item *
 
-L<Statocles::Deploy> - Base deploy role
+L<Statocles::Role::Deploy> - Base deploy role
 
 =over 4
 

--- a/lib/Statocles/Help.pod
+++ b/lib/Statocles/Help.pod
@@ -144,7 +144,7 @@ L<Statocles::Link> - A link to another place
 
 =item *
 
-L<Statocles::Page> - Base page role
+L<Statocles::Role::Page> - Base page role
 
 =over 4
 

--- a/lib/Statocles/Help.pod
+++ b/lib/Statocles/Help.pod
@@ -172,7 +172,7 @@ L<Statocles::Page::Plain> - Page with pre-generated HTML
 
 =item *
 
-L<Statocles::Plugin> - Base class for Statocles plugins
+L<Statocles::Role::Plugin> - Base role for Statocles plugins
 
 =over 4
 

--- a/lib/Statocles/Help.pod
+++ b/lib/Statocles/Help.pod
@@ -48,7 +48,7 @@ L<Statocles>
 
 =item *
 
-L<Statocles::App> - Base app role
+L<Statocles::Role::App> - Base app role
 
 =over 4
 

--- a/lib/Statocles/Help/Config.pod
+++ b/lib/Statocles/Help/Config.pod
@@ -40,7 +40,7 @@ More on that later.
 =head2 An App
 
 A L<Statocles app|Statocles::Role::App> is the driver that turns documents into
-L<pages|Statocles::Page>. To build pages, we need a store full of documents. We
+L<pages|Statocles::Role::Page>. To build pages, we need a store full of documents. We
 define our store with the string C<blog>, which will get magically coerced into
 a L<store object|Statocles::Store>.
 

--- a/lib/Statocles/Help/Config.pod
+++ b/lib/Statocles/Help/Config.pod
@@ -61,7 +61,7 @@ C</>, later).
 =head2 A Deploy
 
 To deploy our site to Github, we need to build a L<deploy
-object|Statocles::Deploy> for Git repositories using
+object|Statocles::Role::Deploy> for Git repositories using
 L<Statocles::Deploy::Git|Statocles::Deploy::Git>. Our deploy object will copy
 our built pages into the Git repository and commit them. Our deploy will happen
 in the root directory of our site on the C<gh-pages> branch.

--- a/lib/Statocles/Help/Config.pod
+++ b/lib/Statocles/Help/Config.pod
@@ -39,7 +39,7 @@ More on that later.
 
 =head2 An App
 
-A L<Statocles app|Statocles::App> is the driver that turns documents into
+A L<Statocles app|Statocles::Role::App> is the driver that turns documents into
 L<pages|Statocles::Page>. To build pages, we need a store full of documents. We
 define our store with the string C<blog>, which will get magically coerced into
 a L<store object|Statocles::Store>.

--- a/lib/Statocles/Help/Config.pod
+++ b/lib/Statocles/Help/Config.pod
@@ -405,7 +405,7 @@ Each plugin has a name (C<highlight>), and requires a C<$class> (the
 class name of the plugin) and optional C<$args> (the plugin's
 attributes).
 
-See L<the list of bundled plugins|Statocles::Plugin/BUNDLED PLUGINS>.
+See L<the list of bundled plugins|Statocles::Role::Plugin/BUNDLED PLUGINS>.
 
 =head2 Custom Markdown
 

--- a/lib/Statocles/Help/Content.pod
+++ b/lib/Statocles/Help/Content.pod
@@ -16,7 +16,7 @@ file|Statocles::Help::Config>. We can use that name to access the app's
 command-line commands.
 
 Not all applications have or need commands. See L<the application
-documentation|Statocles::App/"SEE ALSO"> for more information.
+documentation|Statocles::Role::App/"SEE ALSO"> for more information.
 
 =head3 Create a Blog Post
 
@@ -211,7 +211,7 @@ When the content is being generated, you have access to the following variables:
 
 =item C<$site> - The current L<site object|Statocles::Site>
 
-=item C<$app> - The current L<app object|Statocles::App>
+=item C<$app> - The current L<app object|Statocles::Role::App>
 
 =back
 

--- a/lib/Statocles/Help/Deploy.pod
+++ b/lib/Statocles/Help/Deploy.pod
@@ -193,5 +193,5 @@ placed.
 =head1 Custom Deploy Module
 
 If none of these work for you, you can build your own deploy module. See
-L<Statocles::Deploy> for details.
+L<Statocles::Role::Deploy> for details.
 

--- a/lib/Statocles/Help/Develop.pod
+++ b/lib/Statocles/Help/Develop.pod
@@ -36,7 +36,7 @@ L<Templates|Statocles::Template> that are given to Pages.
 
 =item *
 
-Finally, the Site writes the Page to a L<Deploy|Statocles::Deploy>.
+Finally, the Site writes the Page to a L<Deploy|Statocles::Role::Deploy>.
 
 =back
 

--- a/lib/Statocles/Help/Develop.pod
+++ b/lib/Statocles/Help/Develop.pod
@@ -23,7 +23,7 @@ L<Stores|Statocles::Store> read and write documents.
 =item *
 
 L<Applications|Statocles::Role::App> use Stores to read documents and create
-L<Pages|Statocles::Page>.
+L<Pages|Statocles::Role::Page>.
 
 =item *
 
@@ -100,7 +100,7 @@ with no processing whatsoever.
 
 =head1 PAGES
 
-A L<Statocles::Page> is collected information ready to be rendered into HTML
+A L<Statocles::Role::Page> is collected information ready to be rendered into HTML
 (or whatever). Statocles Applications generate pages from the documents that
 the user provides. One document may generate multiple pages, and pages may have
 multiple formats like HTML or RSS.

--- a/lib/Statocles/Help/Develop.pod
+++ b/lib/Statocles/Help/Develop.pod
@@ -22,7 +22,7 @@ L<Stores|Statocles::Store> read and write documents.
 
 =item *
 
-L<Applications|Statocles::App> use Stores to read documents and create
+L<Applications|Statocles::Role::App> use Stores to read documents and create
 L<Pages|Statocles::Page>.
 
 =item *

--- a/lib/Statocles/Help/Develop.pod
+++ b/lib/Statocles/Help/Develop.pod
@@ -171,7 +171,7 @@ L<Statocles::Plugin::LinkCheck> plugin can search all the pages for
 broken links. For another example, the L<Statocles::Plugin::Highlight>
 plugin adds the C<highlight> function to all the templates in the site.
 
-Plugins consume the L<Statocles::Plugin role|Statocles::Plugin> and must
+Plugins consume the L<Statocles::Plugin role|Statocles::Role::Plugin> and must
 implement the C<register> method to add themselves where they need to be
 added.
 
@@ -198,7 +198,7 @@ Plugins are added to the Site object's C<plugins> attribute:
 
 =head2 Event Handlers
 
-Instead of making an entire Statocles::Plugin, we can respond only to
+Instead of making an entire Statocles::Role::Plugin, we can respond only to
 certain events using Beam::Wire's event handling API.
 
 In this example, we're going to enable the same LinkCheck plugin as

--- a/lib/Statocles/Help/Theme.pod
+++ b/lib/Statocles/Help/Theme.pod
@@ -107,13 +107,13 @@ allow you to evaluate Perl code, which is why the templates are also called
 
 =head2 Template Variables
 
-When an application assembles a L<page object|Statocles::Page>, it sets values
+When an application assembles a L<page object|Statocles::Role::Page>, it sets values
 inside. The page then gives those values to the template. The common values in
 every template are:
 
 =over 4
 
-=item C<$self> - The current L<Statocles::Page|Statocles::Page> object
+=item C<$self> - The current L<Statocles::Role::Page|Statocles::Role::Page> object
 
 =item C<$site> - The current L<Statocles::Site|Statocles::Site> object
 

--- a/lib/Statocles/Help/Theme.pod
+++ b/lib/Statocles/Help/Theme.pod
@@ -117,7 +117,7 @@ every template are:
 
 =item C<$site> - The current L<Statocles::Site|Statocles::Site> object
 
-=item C<$app> - The current L<Statocles::App|Statocles::App> object
+=item C<$app> - The current L<Statocles::Role::App|Statocles::Role::App> object
 
 =back
 

--- a/lib/Statocles/Page.pm
+++ b/lib/Statocles/Page.pm
@@ -28,7 +28,7 @@ The application this page came from, so we can give it to the templates.
 
 has app => (
     is => 'ro',
-    isa => ConsumerOf['Statocles::App'],
+    isa => ConsumerOf['Statocles::Role::App'],
 );
 
 =attr path

--- a/lib/Statocles/Page/Document.pm
+++ b/lib/Statocles/Page/Document.pm
@@ -108,7 +108,7 @@ If true, disables the processing of the content as a template. This will
 improve performance if you're not using any template directives in your content.
 
 This can be set in the document (L<Statocles::Document/disable_content_template>),
-the application (L<Statocles::App/disable_content_template>), or the site
+the application (L<Statocles::Role::App/disable_content_template>), or the site
 (L<Statocles::Site/disable_content_template>).
 
 =cut

--- a/lib/Statocles/Page/Document.pm
+++ b/lib/Statocles/Page/Document.pm
@@ -3,7 +3,7 @@ our $VERSION = '0.094';
 # ABSTRACT: Render document objects into HTML
 
 use Statocles::Base 'Class';
-with 'Statocles::Page';
+with 'Statocles::Role::Page';
 use Statocles::Template;
 use Statocles::Store;
 
@@ -240,7 +240,7 @@ sub tags {
     my $tmpl = $page->template;
 
 The L<template object|Statocles::Template> for this page. If the document has a template,
-it will be used. Otherwise, the L<template attribute|Statocles::Page/template> will
+it will be used. Otherwise, the L<template attribute|Statocles::Role::Page/template> will
 be used.
 
 =cut
@@ -258,7 +258,7 @@ around template => sub {
     my $tmpl = $page->layout;
 
 The L<layout template object|Statocles::Template> for this page. If the document has a layout,
-it will be used. Otherwise, the L<layout attribute|Statocles::Page/layout> will
+it will be used. Otherwise, the L<layout attribute|Statocles::Role::Page/layout> will
 be used.
 
 =cut

--- a/lib/Statocles/Page/File.pm
+++ b/lib/Statocles/Page/File.pm
@@ -3,7 +3,7 @@ our $VERSION = '0.094';
 # ABSTRACT: A page wrapping a file (handle)
 
 use Statocles::Base 'Class';
-with 'Statocles::Page';
+with 'Statocles::Role::Page';
 
 =attr file_path
 
@@ -88,5 +88,5 @@ __END__
 
 =head1 DESCRIPTION
 
-This L<Statocles::Page> wraps a file handle in order to move files from one
+This L<Statocles::Role::Page> wraps a file handle in order to move files from one
 L<store|Statocles::Store> to another.

--- a/lib/Statocles/Page/List.pm
+++ b/lib/Statocles/Page/List.pm
@@ -3,7 +3,7 @@ our $VERSION = '0.094';
 # ABSTRACT: A page presenting a list of other pages
 
 use Statocles::Base 'Class';
-with 'Statocles::Page';
+with 'Statocles::Role::Page';
 use List::Util qw( reduce );
 use Statocles::Template;
 use Statocles::Page::ListItem;
@@ -17,7 +17,7 @@ The pages that should be shown in this list.
 
 has _pages => (
     is => 'ro',
-    isa => ArrayRef[ConsumerOf['Statocles::Page']],
+    isa => ArrayRef[ConsumerOf['Statocles::Role::Page']],
     init_arg => 'pages',
 );
 
@@ -78,7 +78,7 @@ has '+date' => (
 
 =attr search_change_frequency
 
-Override the default L<search_change_frequency|Statocles::Page/search_change_frequency>
+Override the default L<search_change_frequency|Statocles::Role::Page/search_change_frequency>
 to C<daily>, because these pages aggregate other pages.
 
 =cut
@@ -89,7 +89,7 @@ has '+search_change_frequency' => (
 
 =attr search_priority
 
-Override the default L<search_priority|Statocles::Page/search_priority> to reduce
+Override the default L<search_priority|Statocles::Role::Page/search_priority> to reduce
 the rank of list pages to C<0.3>.
 
 It is more important for users to get to the full page than
@@ -184,7 +184,7 @@ around vars => sub {
     my @links = $page->links( $key );
 
 Get the given set of links for this page. See L<the links
-attribute|Statocles::Page/links> for some commonly-used keys.
+attribute|Statocles::Role::Page/links> for some commonly-used keys.
 
 For List pages, C<stylesheet> and C<script> links are also collected
 from the L<inner pages|/pages>, to ensure that content in those pages

--- a/lib/Statocles/Page/ListItem.pm
+++ b/lib/Statocles/Page/ListItem.pm
@@ -7,13 +7,13 @@ use Mojo::DOM;
 
 =attr page
 
-The L<page object|Statocles::Page> for this item in the list.
+The L<page object|Statocles::Role::Page> for this item in the list.
 
 =cut
 
 has page => (
     is => 'ro',
-    isa => ConsumerOf[ 'Statocles::Page' ],
+    isa => ConsumerOf[ 'Statocles::Role::Page' ],
 );
 
 =attr rewrite_mode
@@ -36,7 +36,7 @@ has rewrite_mode => (
 =method DOES
 
 This page proxies everything necessary to be a page object, without consuming
-the L<page role|Statocles::Page>.
+the L<page role|Statocles::Role::Page>.
 
 =cut
 

--- a/lib/Statocles/Page/Plain.pm
+++ b/lib/Statocles/Page/Plain.pm
@@ -3,7 +3,7 @@ our $VERSION = '0.094';
 # ABSTRACT: A plain page (with templates)
 
 use Statocles::Base 'Class';
-with 'Statocles::Page';
+with 'Statocles::Role::Page';
 
 =attr content
 
@@ -47,6 +47,6 @@ __END__
 
 =head1 DESCRIPTION
 
-This L<Statocles::Page> contains any content you want to put in it, while still
+This L<Statocles::Role::Page> contains any content you want to put in it, while still
 allowing for templates and layout. This is useful when you generate HTML (or
 anything else) outside of Statocles.

--- a/lib/Statocles/Plugin/Diagram/Mermaid.pm
+++ b/lib/Statocles/Plugin/Diagram/Mermaid.pm
@@ -33,7 +33,7 @@ diagrams.
 
 use Mojo::URL;
 use Statocles::Base 'Class';
-with 'Statocles::Plugin';
+with 'Statocles::Role::Plugin';
 
 
 =attr mermaid_url

--- a/lib/Statocles/Plugin/HTMLLint.pm
+++ b/lib/Statocles/Plugin/HTMLLint.pm
@@ -3,7 +3,7 @@ our $VERSION = '0.094';
 # ABSTRACT: Check HTML for common errors and issues
 
 use Statocles::Base 'Class';
-with 'Statocles::Plugin';
+with 'Statocles::Role::Plugin';
 BEGIN {
     eval { require HTML::Lint::Pluggable; HTML::Lint::Pluggable->VERSION( 0.06 ); 1 }
         or die "Error loading Statocles::Plugin::HTMLLint. To use this plugin, install HTML::Lint::Pluggable";

--- a/lib/Statocles/Plugin/Highlight.pm
+++ b/lib/Statocles/Plugin/Highlight.pm
@@ -30,7 +30,7 @@ configuration blocks.
 =cut
 
 use Statocles::Base 'Class';
-with 'Statocles::Plugin';
+with 'Statocles::Role::Plugin';
 BEGIN {
     eval { require Syntax::Highlight::Engine::Kate; 1 }
         or die "Error loading Statocles::Plugin::Highlight. To use this plugin, install Syntax::Highlight::Engine::Kate";

--- a/lib/Statocles/Plugin/LinkCheck.pm
+++ b/lib/Statocles/Plugin/LinkCheck.pm
@@ -3,7 +3,7 @@ our $VERSION = '0.094';
 # ABSTRACT: Check links and images for validity during build
 
 use Statocles::Base 'Class';
-with 'Statocles::Plugin';
+with 'Statocles::Role::Plugin';
 use Mojo::Util qw( url_escape url_unescape );
 
 =attr ignore

--- a/lib/Statocles/Role/App.pm
+++ b/lib/Statocles/Role/App.pm
@@ -96,7 +96,7 @@ has disable_content_template => (
 
     my @pages = $app->pages;
 
-Get the pages for this app. Must return a list of L<Statocles::Page> objects.
+Get the pages for this app. Must return a list of L<Statocles::Role::Page> objects.
 
 =cut
 
@@ -175,7 +175,7 @@ name. The default template is determined by the app's class name and the
 template name passed in.
 
 Applications should list the templates they have and describe what L<page
-class|Statocles::Page> they use.
+class|Statocles::Role::Page> they use.
 
 =cut
 
@@ -212,7 +212,7 @@ __END__
 
 =head1 DESCRIPTION
 
-A Statocles App creates a set of L<pages|Statocles::Pages> that can then be
+A Statocles App creates a set of L<page|Statocles::Role::Page>s that can then be
 written to the filesystem (or served directly, if desired).
 
 Pages can be created from L<documents|Statocles::Documents> stored in a
@@ -256,7 +256,7 @@ These applications are included with the core Statocles distribution.
 
 =item L<Statocles::Store>
 
-=item L<Statocles::Page>
+=item L<Statocles::Role::Page>
 
 =back
 

--- a/lib/Statocles/Role/App.pm
+++ b/lib/Statocles/Role/App.pm
@@ -1,4 +1,4 @@
-package Statocles::App;
+package Statocles::Role::App;
 our $VERSION = '0.094';
 # ABSTRACT: Base role for Statocles applications
 
@@ -201,7 +201,7 @@ __END__
 
     package MyApp;
     use Statocles::Base 'Class';
-    with 'Statocles::App';
+    with 'Statocles::Role::App';
 
     sub pages {
         return Statocles::Page::Content->new(

--- a/lib/Statocles/Role/App/Store.pm
+++ b/lib/Statocles/Role/App/Store.pm
@@ -1,4 +1,4 @@
-package Statocles::App::Role::Store;
+package Statocles::Role::App::Store;
 our $VERSION = '0.094';
 # ABSTRACT: Role for applications using files
 
@@ -6,7 +6,7 @@ our $VERSION = '0.094';
 
     package MyApp;
     use Statocles::Base 'Class';
-    with 'Statocles::App::Role::Store';
+    with 'Statocles::Role::App::Store';
 
     around pages => sub {
         my ( $orig, $self, %options ) = @_;
@@ -21,6 +21,8 @@ our $VERSION = '0.094';
 
 This role provides some basic functionality for those applications that want
 to use L<store objects|Statocles::Store> to manage content with Markdown files.
+It can be considered an extension (though it is actually a consumer)
+of the role L<Statocles::Role::App>.
 
 =cut
 

--- a/lib/Statocles/Role/Deploy.pm
+++ b/lib/Statocles/Role/Deploy.pm
@@ -1,4 +1,4 @@
-package Statocles::Deploy;
+package Statocles::Role::Deploy;
 our $VERSION = '0.094';
 # ABSTRACT: Base role for ways to deploy a site
 
@@ -49,7 +49,7 @@ __END__
 
 =head1 DESCRIPTION
 
-A Statocles::Deploy deploys a site to a destination, like Git, SFTP, or
+A Statocles::Role::Deploy deploys a site to a destination, like Git, SFTP, or
 otherwise.
 
 =head1 SEE ALSO

--- a/lib/Statocles/Role/Page.pm
+++ b/lib/Statocles/Role/Page.pm
@@ -1,4 +1,4 @@
-package Statocles::Page;
+package Statocles::Role::Page;
 our $VERSION = '0.094';
 # ABSTRACT: Base role for rendering files
 
@@ -264,8 +264,8 @@ sub vars {
 
     my $html = $page->render( %vars );
 
-Render the page, using the L<template|Statocles::Page/template> and wrapping
-with the L<layout|Statocles::Page/layout>. Give any extra C<%vars> to the
+Render the page, using the L<template|Statocles::Role::Page/template> and wrapping
+with the L<layout|Statocles::Role::Page/layout>. Give any extra C<%vars> to the
 template, layout, and page C<content> method (if applicable).
 
 The result of this method is cached.
@@ -333,7 +333,7 @@ __END__
 
 =head1 DESCRIPTION
 
-A Statocles::Page takes one or more L<documents|Statocles::Document> and
+A Statocles::Role::Page takes one or more L<documents|Statocles::Document> and
 renders them into one or more HTML pages using a main L<template|/template>
 and a L<layout template|/layout>.
 

--- a/lib/Statocles/Role/Plugin.pm
+++ b/lib/Statocles/Role/Plugin.pm
@@ -1,4 +1,4 @@
-package Statocles::Plugin;
+package Statocles::Role::Plugin;
 our $VERSION = '0.094';
 # ABSTRACT: Base role for Statocles plugins
 
@@ -7,7 +7,7 @@ our $VERSION = '0.094';
     # lib/My/Plugin.pm
     package My::Plugin;
     use Moo; # or Moose
-    with 'Statocles::Plugin';
+    with 'Statocles::Role::Plugin';
 
     sub register {
         my ( $self, $site ) = @_;
@@ -91,7 +91,7 @@ plugin itself. For example,
 
     package My::Plugin {
         use Statocles::Base 'Class';
-        with 'Statocles::Plugin';
+        with 'Statocles::Role::Plugin';
 
         has myattr => (
             is => 'ro',

--- a/lib/Statocles/Site.pm
+++ b/lib/Statocles/Site.pm
@@ -390,7 +390,7 @@ while they are being rendered.
 
 has _pages => (
     is => 'rw',
-    isa => ArrayRef[ConsumerOf['Statocles::Page']],
+    isa => ArrayRef[ConsumerOf['Statocles::Role::Page']],
     default => sub { [] },
     lazy => 1,
     predicate => 'has_pages',
@@ -730,7 +730,7 @@ name. The default template is determined by the app's class name and the
 template name passed in.
 
 Applications should list the templates they have and describe what L<page
-class|Statocles::Page> they use.
+class|Statocles::Role::Page> they use.
 
 =cut
 

--- a/lib/Statocles/Site.pm
+++ b/lib/Statocles/Site.pm
@@ -50,7 +50,7 @@ has author => (
 
 The base URL of the site, including protocol and domain. Used mostly for feeds.
 
-This can be overridden by L<base_url in Deploy|Statocles::Deploy/base_url>.
+This can be overridden by L<base_url in Deploy|Statocles::Role::Deploy/base_url>.
 
 =cut
 
@@ -296,7 +296,7 @@ has template_dir => (
 
 =attr deploy
 
-The L<deploy object|Statocles::Deploy> to use for C<deploy()>. This is
+The L<deploy object|Statocles::Role::Deploy> to use for C<deploy()>. This is
 intended to be the production deployment of the site. A build gets promoted to
 production by using the C<deploy> command.
 
@@ -304,7 +304,7 @@ production by using the C<deploy> command.
 
 has deploy => (
     is => 'ro',
-    isa => ConsumerOf['Statocles::Deploy'],
+    isa => ConsumerOf['Statocles::Role::Deploy'],
     required => 1,
     coerce => sub {
         if ( ( blessed $_[0] && $_[0]->isa( 'Path::Tiny' ) ) || !ref $_[0] ) {

--- a/lib/Statocles/Site.pm
+++ b/lib/Statocles/Site.pm
@@ -85,7 +85,7 @@ that can be used later.
 
 has apps => (
     is => 'ro',
-    isa => HashRef[ConsumerOf['Statocles::App']],
+    isa => HashRef[ConsumerOf['Statocles::Role::App']],
     default => sub { {} },
 );
 
@@ -367,7 +367,7 @@ This disables processing the content as a template. This can speed up processing
 when the content is not using template directives. 
 
 This can be also set in the application
-(L<Statocles::App/disable_content_template>), or for each document
+(L<Statocles::Role::App/disable_content_template>), or for each document
 (L<Statocles::Document/disable_content_template>).
 
 =cut
@@ -778,7 +778,7 @@ __END__
 
 =head1 DESCRIPTION
 
-A Statocles::Site is a collection of L<applications|Statocles::App>.
+A Statocles::Site is a collection of L<applications|Statocles::Role::App>.
 
 =head1 EVENTS
 

--- a/lib/Statocles/Site.pm
+++ b/lib/Statocles/Site.pm
@@ -97,7 +97,7 @@ The plugins in this site. Each plugin has a name that can be used later.
 
 has plugins => (
     is => 'ro',
-    isa => HashRef[ConsumerOf['Statocles::Plugin']],
+    isa => HashRef[ConsumerOf['Statocles::Role::Plugin']],
     default => sub { {} },
 );
 

--- a/lib/Statocles/Site.pm
+++ b/lib/Statocles/Site.pm
@@ -493,7 +493,7 @@ sub pages {
     for my $app_name ( keys %{ $apps } ) {
         my $app = $apps->{$app_name};
         my $index_path_re = qr{^$index_path(?:/index[.]html)?$};
-        if ( $app->DOES( 'Statocles::App::Role::Store' ) ) {
+        if ( $app->DOES( 'Statocles::Role::App::Store' ) ) {
             # Allow index to be path to document and not the resulting page
             # (so, ending in ".markdown" or ".md")
             my $doc_path = $index_path;

--- a/lib/Statocles/Store.pm
+++ b/lib/Statocles/Store.pm
@@ -135,7 +135,7 @@ sub has_file {
     $store->write_file( $path, $content );
 
 Write the given C<content> to the given C<path>. This is mostly used to write
-out L<page objects|Statocles::Page>.
+out L<page objects|Statocles::Role::Page>.
 
 C<content> may be a simple string or a filehandle. If given a string, will
 write the string using UTF-8 characters. If given a filehandle, will write out
@@ -276,7 +276,7 @@ __END__
 =head1 DESCRIPTION
 
 A Statocles::Store reads and writes L<documents|Statocles::Document> and
-files (mostly L<pages|Statocles::Page>).
+files (mostly L<pages|Statocles::Role::Page>).
 
 This class also handles the parsing and inflating of
 L<"document objects"|Statocles::Document>.

--- a/lib/Statocles/Template.pm
+++ b/lib/Statocles/Template.pm
@@ -369,7 +369,7 @@ L<markdown helper|/markdown> to render the markdown into HTML.
     %= markdown include 'path/include.markdown'
 
 Render the given markdown text into HTML. This is useful for allowing users to
-write markdown in L<site data|Statocles::Site/data>, and L<app data|Statocles::App/data> in
+write markdown in L<site data|Statocles::Site/data>, and L<app data|Statocles::Role::App/data> in
 the L<configuration file|Statocles::Help::Config/data>,
 or L<document data|Statocles::Document/data> attributes in the document frontmatter.
 

--- a/lib/Statocles/Test.pm
+++ b/lib/Statocles/Test.pm
@@ -185,7 +185,7 @@ sub test_pages {
     $tb->is_eq( scalar @pages, scalar keys %page_tests, 'correct number of pages' );
 
     for my $page ( @pages ) {
-        $tb->ok( $page->DOES( 'Statocles::Page' ), 'must be a Statocles::Page' );
+        $tb->ok( $page->DOES( 'Statocles::Role::Page' ), 'must be a Statocles::Role::Page' );
 
         my $date   = $page->date;
         my $want   = 'DateTime::Moonpig';

--- a/lib/Statocles/Theme.pm
+++ b/lib/Statocles/Theme.pm
@@ -204,7 +204,7 @@ sub include {
 
 Register a helper on this theme. Helpers are functions that are added to
 the template to allow for additional features. Helpers are usually added
-by L<Statocles plugins|Statocles::Plugin>.
+by L<Statocles plugins|Statocles::Role::Plugin>.
 
 There are a L<default set of helpers available to all
 templates|Statocles::Template/DEFAULT HELPERS> which cannot be

--- a/lib/Statocles/Theme.pm
+++ b/lib/Statocles/Theme.pm
@@ -6,7 +6,7 @@ use Statocles::Base 'Class';
 use File::Share qw( dist_dir );
 use Scalar::Util qw( blessed );
 use Statocles::Template;
-with 'Statocles::App::Role::Store';
+with 'Statocles::Role::App::Store';
 
 =attr url_root
 

--- a/lib/Statocles/Theme.pm
+++ b/lib/Statocles/Theme.pm
@@ -272,7 +272,7 @@ __END__
 =head1 DESCRIPTION
 
 A Theme contains all the L<templates|Statocles::Template> that
-L<applications|Statocles::App> need. This class handles finding and parsing
+L<applications|Statocles::Role::App> need. This class handles finding and parsing
 files into L<template objects|Statocles::Template>.
 
 When the L</store> is read, the templates inside are organized based on

--- a/t/app/role/store.t
+++ b/t/app/role/store.t
@@ -7,7 +7,7 @@ my $SHARE_DIR = path( __DIR__ )->parent->parent->child( 'share' );
 {
     package MyApp;
     use Statocles::Base 'Class';
-    with 'Statocles::App::Role::Store';
+    with 'Statocles::Role::App::Store';
     around pages => sub {
         my ( $orig, $self, %options ) = @_;
         my @pages = $self->$orig( %options );

--- a/t/app/template.t
+++ b/t/app/template.t
@@ -1,9 +1,6 @@
 
 use Test::Lib;
 use My::Test;
-use Statocles::Site;
-use Statocles::Role::App;
-use Statocles::App::Blog;
 use TestApp;
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );
 

--- a/t/app/template.t
+++ b/t/app/template.t
@@ -2,7 +2,7 @@
 use Test::Lib;
 use My::Test;
 use Statocles::Site;
-use Statocles::App;
+use Statocles::Role::App;
 use Statocles::App::Blog;
 use TestApp;
 my $SHARE_DIR = path( __DIR__ )->parent->child( 'share' );

--- a/t/app/url.t
+++ b/t/app/url.t
@@ -2,7 +2,6 @@
 use Test::Lib;
 use My::Test;
 use Statocles::Site;
-use Statocles::Role::App;
 use TestApp;
 
 my $site = Statocles::Site->new( deploy => tempdir );

--- a/t/app/url.t
+++ b/t/app/url.t
@@ -2,7 +2,7 @@
 use Test::Lib;
 use My::Test;
 use Statocles::Site;
-use Statocles::App;
+use Statocles::Role::App;
 use TestApp;
 
 my $site = Statocles::Site->new( deploy => tempdir );

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -205,10 +205,10 @@ subtest 'Statocles::Test::test_pages' => sub {
         eval "
         package Statocles::App::MockTest;
         use Statocles::Base 'Class';
-        with 'Statocles::App';
+        with 'Statocles::Role::App';
         sub pages { return () }
         1
-      " or die "Cant construct a Statocles::App: $@";
+      " or die "Cant construct a Statocles::Role::App: $@";
 
         my $site = build_test_site();
 

--- a/t/lib/My/Test.pm
+++ b/t/lib/My/Test.pm
@@ -150,7 +150,7 @@ sub test_pages {
     ) or $tb->diag( "Extra pages tested: " . join( ", ", sort keys %page_tests_copy ) );
 
     for my $page (@pages) {
-        $tb->ok( $page->DOES('Statocles::Page'), 'must be a Statocles::Page' );
+        $tb->ok( $page->DOES('Statocles::Role::Page'), 'must be a Statocles::Role::Page' );
 
         my $date   = $page->date;
         my $want   = 'DateTime::Moonpig';
@@ -247,7 +247,7 @@ sub test_page_objects {
     ) or $tb->diag( "Test defined but no page found: " . join( ", ", sort keys %page_tests_copy ) );
 
     for my $page (@$pages) {
-        $tb->ok( $page->DOES('Statocles::Page'), 'must be a Statocles::Page' );
+        $tb->ok( $page->DOES('Statocles::Role::Page'), 'must be a Statocles::Role::Page' );
 
         my $date   = $page->date;
         my $want   = 'DateTime::Moonpig';

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -8,7 +8,7 @@ with 'Statocles::Role::App';
 
 has _pages => (
     is => 'ro',
-    isa => ArrayRef[ConsumerOf['Statocles::Page']|HashRef],
+    isa => ArrayRef[ConsumerOf['Statocles::Role::Page']|HashRef],
     init_arg => 'pages',
     default => sub { [] },
 );

--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -4,7 +4,7 @@ package
 use Statocles::Base 'Class';
 use Scalar::Util qw( blessed );
 use Statocles::Page::Plain;
-with 'Statocles::App';
+with 'Statocles::Role::App';
 
 has _pages => (
     is => 'ro',

--- a/t/lib/TestDeploy.pm
+++ b/t/lib/TestDeploy.pm
@@ -1,7 +1,7 @@
 package TestDeploy;
 
 use Statocles::Base 'Class';
-with 'Statocles::Deploy';
+with 'Statocles::Role::Deploy';
 
 has last_deploy_args => ( is => 'rw' );
 

--- a/t/page/basename.t
+++ b/t/page/basename.t
@@ -8,7 +8,7 @@ my $site = Statocles::Site->new( deploy => tempdir );
 {
     package TestPage;
     use Statocles::Base 'Class';
-    with 'Statocles::Page';
+    with 'Statocles::Role::Page';
 }
 
 subtest 'basename' => sub {

--- a/t/page/images.t
+++ b/t/page/images.t
@@ -8,7 +8,7 @@ my $site = Statocles::Site->new( deploy => tempdir );
 {
     package TestPage;
     use Statocles::Base 'Class';
-    with 'Statocles::Page';
+    with 'Statocles::Role::Page';
 }
 
 subtest 'images' => sub {

--- a/t/page/links.t
+++ b/t/page/links.t
@@ -8,7 +8,7 @@ my $site = Statocles::Site->new( deploy => tempdir );
 {
     package TestPage;
     use Statocles::Base 'Class';
-    with 'Statocles::Page';
+    with 'Statocles::Role::Page';
 }
 
 subtest 'links' => sub {

--- a/t/page/type.t
+++ b/t/page/type.t
@@ -7,7 +7,7 @@ my $site = Statocles::Site->new( deploy => tempdir );
 {
     package TestPage;
     use Statocles::Base 'Class';
-    with 'Statocles::Page';
+    with 'Statocles::Role::Page';
 }
 
 sub test_type {

--- a/t/plugin.t
+++ b/t/plugin.t
@@ -10,7 +10,7 @@ my $SHARE_DIR = path( __DIR__, '..', 'share' );
     package My::Plugin;
 
     use Statocles::Base 'Class';
-    with 'Statocles::Plugin';
+    with 'Statocles::Role::Plugin';
 
     has _register_called => (
         is => 'rw',


### PR DESCRIPTION
This changes all roles from being eg `Statocles::App` to `Statocles::Role::App`.

Reasoning: the thing I found most confusing when digging into the code previously was the module `Statocles::App::Role::Store` - now that it's renamed to `Statocles::Role::App::Store` (and with the additional doc snippet saying it's effectively an extension of `Statocles::Role::App`), I find it far more comprehensible. Similarly, all other roles being called `Statocles::Role::*` is far more clear to my comprehension.