### PR TITLE
decode the current locale from all input

### DIFF
--- a/bin/statocles
+++ b/bin/statocles
@@ -3,6 +3,12 @@
 package statocles;
 our $VERSION = '0.094';
 
+use Statocles::Base;
+use Encode qw( decode );
+use Encode::Locale;
+use open qw( :std :locale );
+use POSIX qw( setlocale LC_ALL );
+
 # Mojolicious::Commands currently calls GetOptions and clobbers a few of
 # our command-line options. Since I don't want to rely on the envvars
 # that get set in that process, we'll do this little dance here.
@@ -11,7 +17,11 @@ our $VERSION = '0.094';
 # module, which loads Mojolicious, which loads Mojolicious::Commands, which
 # calls GetOptions on @ARGV
 my @argv;
-BEGIN { @argv = @ARGV };
+BEGIN { @argv = map { decode( locale => $_ ) } @ARGV };
+
+binmode STDIN, ":encoding(locale)";
+binmode STDOUT, ":encoding(locale)";
+binmode STDERR, ":encoding(locale)";
 
 use Statocles;
 exit Statocles->run( @argv );

--- a/dist.ini
+++ b/dist.ini
@@ -122,6 +122,8 @@ strict = 0
 warnings = 0
 Encode = 0
 Pod::Simple = 3.31 ; Fixes "Use of uninitialized value $1 in lc" warning in Pod::Simple::Search
+I18N::Langinfo = 0
+IPC::Open3 = 0
 
 ; Non-core deps
 ; We're going pure-perl here (eventually)
@@ -142,6 +144,7 @@ Types::Path::Tiny = 0
 List::UtilsBy = 0.09
 DateTime::Moonpig = 0
 Text::Unidecode = 0
+Encode::Locale = 0
 
 [Prereqs / Recommends]
 Pod::Weaver = 4.015

--- a/lib/Statocles.pm
+++ b/lib/Statocles.pm
@@ -64,6 +64,8 @@ sub run {
 
     if ( $opt{version} || ( $opt{verbose} && !@argv ) ) {
         say "Statocles version $Statocles::VERSION (Perl $^V)";
+        require POSIX;
+        say "Locale: " . POSIX::setlocale( POSIX::LC_CTYPE );
         return 0;
     }
 

--- a/t/command/help_and_version.t
+++ b/t/command/help_and_version.t
@@ -29,13 +29,17 @@ subtest 'get version' => sub {
     my ( $output, $stderr, $exit ) = capture { Statocles->run( '--version' ) };
     is $exit, 0;
     ok !$stderr, 'stderr is empty' or diag "STDERR: $stderr";
-    is $output, "Statocles version 1.00 (Perl $^V)\n";
+    my $expected = <<EOF;
+Statocles version 1.00 (Perl $^V)
+Locale: en_US.UTF-8
+EOF
+    is $output, $expected;
 
     subtest '-v (verbose) and no args shows version' => sub {
         my ( $output, $stderr, $exit ) = capture { Statocles->run( '-v' ) };
         is $exit, 0;
         ok !$stderr, 'stderr is empty' or diag "STDERR: $stderr";
-        is $output, "Statocles version 1.00 (Perl $^V)\n";
+        is $output, $expected;
     };
 };
 

--- a/t/command/help_and_version.t
+++ b/t/command/help_and_version.t
@@ -4,7 +4,9 @@ use My::Test;
 use Capture::Tiny qw( capture );
 use FindBin ();
 use Statocles;
+use POSIX qw( setlocale LC_ALL LC_CTYPE );
 my $SHARE_DIR = path( __DIR__, '..', 'share' );
+my $FORCE_LOCALE = "en_US.UTF-8";
 
 subtest 'get help' => sub {
     local $0 = path( $FindBin::Bin, '..', '..', 'bin', 'statocles' )->stringify;
@@ -26,6 +28,10 @@ subtest 'get help' => sub {
 
 subtest 'get version' => sub {
     local $Statocles::VERSION = '1.00';
+    setlocale( LC_ALL, $FORCE_LOCALE );
+    local $ENV{LANG} = $FORCE_LOCALE;
+    local $ENV{LC_ALL} = $FORCE_LOCALE;
+    local $ENV{LC_CTYPE} = $FORCE_LOCALE;
     my ( $output, $stderr, $exit ) = capture { Statocles->run( '--version' ) };
     is $exit, 0;
     ok !$stderr, 'stderr is empty' or diag "STDERR: $stderr";

--- a/t/statocles.t
+++ b/t/statocles.t
@@ -1,0 +1,97 @@
+# This test file duplicates some tests in t/command.t to ensure that
+# the bin/statocles frontend's delegation to Statocles.pm
+# works.
+use Test::Lib;
+use My::Test;
+use Capture::Tiny qw( capture );
+use Encode qw( encode decode );
+use POSIX qw( setlocale LC_ALL LC_CTYPE );
+use Mojo::Path;
+use IPC::Open3;
+use Symbol 'gensym';
+
+my $BIN = path( __DIR__, '..', 'bin', 'statocles' );
+my $SHARE_DIR = path( __DIR__, 'share' );
+my $SITE = build_test_site;
+my $FORCE_LOCALE = "en_US.UTF-8";
+
+subtest '-h|--help' => sub {
+    subtest '-h' => sub {
+        my ( $out, $err, $exit ) = capture { system $^X, $BIN, '-h' };
+        ok !$err, 'nothing on stderr' or diag "STDERR: $err";
+        like $out, qr{statocles -h},
+            'reports pod from bin/statocles, not Statocles';
+        is $exit, 0;
+    };
+    subtest '--help' => sub {
+        my ( $out, $err, $exit ) = capture { system $^X, $BIN, '--help' };
+        ok !$err, 'nothing on stderr' or diag "STDERR: $err";
+        like $out, qr{statocles -h},
+            'reports pod from bin/statocles, not Statocles';
+        is $exit, 0;
+    };
+};
+
+subtest 'handle locales on ARGV and STDIN' => sub {
+    my ( $tmpdir, $config_fn, $config ) = build_temp_site( $SHARE_DIR );
+
+    local $ENV{EDITOR}; # We can't very well open vim...
+    my $locale = setlocale( LC_ALL );
+    diag "Current locale: $locale";
+    setlocale( LC_ALL, $FORCE_LOCALE );
+    local $ENV{LANG} = $FORCE_LOCALE;
+    local $ENV{LC_ALL} = $FORCE_LOCALE;
+    local $ENV{LC_CTYPE} = $FORCE_LOCALE;
+
+    my $title_chars = "Test æøå";
+    my $title_encoded = encode( $FORCE_LOCALE => $title_chars );
+    my $content_chars = "\xa9\n";
+    my $content_encoded = encode( $FORCE_LOCALE => $content_chars );
+    my ( undef, undef, undef, $day, $mon, $year ) = localtime;
+    my @partsfile = (
+        'blog',
+        sprintf( '%04i', $year + 1900 ),
+        sprintf( '%02i', $mon + 1 ),
+        sprintf( '%02i', $day ),
+        'test-a-a-ay', # what make_slug turns that title to
+        'index.markdown',
+    );
+    my $doc_path = $tmpdir->child( @partsfile );
+
+    subtest 'run the command' => sub {
+        my @args = ( '--config', $config_fn, qw( blog post ), $title_encoded );
+        my $cwd = cwd;
+        chdir $tmpdir;
+        open3 my $child_in, my $child_out, (my $child_err = gensym), $^X, $BIN, @args;
+        print {$child_in} $content_encoded;
+        close $child_in;
+        my ( $out, $err ) = do { local $/; (<$child_out>, <$child_err>) };
+        chdir $cwd;
+        is $err, undef, 'nothing on stderr';
+        is $?, 0;
+        my $decoded_out = decode( $FORCE_LOCALE => $out );
+        like $decoded_out, qr{New post at: \Q$doc_path},
+            'contains blog post document path';
+    };
+
+    subtest 'check the generated document' => sub {
+        my $store = Statocles::Store->new( path => $tmpdir->child( 'blog' ) );
+        my $doc = Statocles::Document->parse_content(
+            path => path( @partsfile ).'',
+            store => $store,
+            content => $doc_path->slurp_utf8,
+        );
+        is $doc->title, $title_chars;
+        is_deeply $doc->tags, [] or diag explain $doc->tags;
+        is $doc->content, $content_chars;
+        eq_or_diff $doc_path->slurp_utf8, <<ENDCONTENT;
+---
+status: published
+title: $title_chars
+---
+\xa9
+ENDCONTENT
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Based heavily on @preaction's utf8-everywhere branch. Fixes #278.