### PR TITLE
Support content sections on systems with line endings other than \n

### DIFF
--- a/lib/Statocles/Page/Document.pm
+++ b/lib/Statocles/Page/Document.pm
@@ -210,7 +210,7 @@ sub sections {
         @sections =
             map { $self->markdown->markdown( $_ ) }
             map { $self->_render_content_template( $_, {} ) }
-            split /\n---\n/,
+            split /\R---\R/,
             $self->document->content;
 
         $self->_rendered_sections( \@sections );


### PR DESCRIPTION
I use a Mac. I tried to an old markdown file that I created on Windows, it didn't have content sections working, and I wanted my post to be a short summary with "read more". I figured it out by accident - when using `statocles blog post < windows_file.markdown` and opening the file showed me various ^M characters. I then searched the codebase for where it might split on "---", and found this regex: the change from \n to \R fixed the issue.