### PR TITLE
Avoid can't call method "log" on undefined object

### DIFF
--- a/lib/Statocles/Command/bundle.pm
+++ b/lib/Statocles/Command/bundle.pm
@@ -45,7 +45,7 @@ sub bundle_theme {
         my $dest = $theme_dest->child( $path );
         # Don't overwrite site-customized hooks
         next if ( $abs_path->stat->size == 0 && $dest->exists );
-        site->log->debug( sprintf 'Copying theme file "%s" to "%s"', $path, $dest );
+        printf STDERR "Copying theme file \"%s\" to \"%s\"\n", $path, $dest;
         $dest->remove if $dest->exists;
         $dest->parent->mkpath;
         $abs_path->copy( $dest );


### PR DESCRIPTION
When creating a new Statocles project with v0.093, if you use the default theme, the code throws an exception, trying to call site->log at line 48 of bundle.pm.

```
Can't call method "log" on an undefined value at
/home/dfarrell/.plenv/versions/5.26.0/lib/perl5/site_perl/5.26.0/Statocles.pm line 171, <STDIN> line 3.
```

site is undefined at this point. A better fix might be to initialize it
first, but I wasn't sure if site can exist before the Statocles project
has been created.

Feel free to reject this PR if you see a better way to fix it.

To reproduce:
```
$ statocles create www.example.com

Welcome to Statocles!

First, select a flavor. The flavor determines which applications will be
configured by default.

1) Blog

This flavor puts a blog as the main page, though you may add other pages
later.

2) Project

This flavor puts a plain Markdown file as the main page and adds a blog
for release announcements.

0) None

No applications will be preconfigured. You can add applications later.
See Statocles::Help::Config for details.

Which flavor of site would you like? ([1], 2, 0) 1


Statocles comes with a default theme based on the Skeleton CSS library.
If you want, I can copy this default theme into the current directory so
that you can fully customize it to your liking.

Instead, you can make some minor alterations in content and color using
"include_stores". See Statocles::Help::Theme for more information.

You can always copy or restore the default theme later using the
"statocles bundle" command.

Do you want to bundle the theme? ([Y]/n) y


Statocles can deploy your site in multiple ways.

1) Git

Statocles will commit your site to a Git repository and push to a remote

2) Copy files

Statocles will copy your site to another directory for your web server
to serve.

0) None

Don't set up a deploy yet. "statocles deploy" will just write the site
to the current directory. You can set up a deploy later. See
Statocles::Help::Deploy for details.

How would you like to deploy? ([1], 2, 0) 0
Can't call method "log" on an undefined value at /home/dfarrell/.plenv/versions/5.26.0/lib/perl5/site_perl/5.26.0/Statocles.pm line 171, <STDIN> line 3.
```