### PR TITLE
Simplify the link POD

### DIFF
--- a/lib/Statocles/Help.pod
+++ b/lib/Statocles/Help.pod
@@ -232,6 +232,6 @@ Be patient, it's a slow channel.
 
 =head1 SEE ALSO
 
-For news and documentation, L<visit the Statocles website at
-http:E<sol>E<sol>preaction.me<sol>statocles|http://preaction.me/statocles>.
+For news and documentation, visit the Statocles website at
+L<http://preaction.me/statocles>.
 


### PR DESCRIPTION
Currently https://metacpan.org/pod/Statocles::Help#SEE-ALSO shows a broken link to https://preaction.me - this simplifies and fixes it.