### PR TITLE
add build_date to site, set during build

### DIFF
--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -451,7 +451,7 @@ Defaults to the current date.
 
 sub pages {
     my ( $self, $pages, %opt ) = @_;
-    $opt{date} ||= DateTime::Moonpig->now( time_zone => 'local' )->ymd;
+    $opt{date} ||= $self->site->build_date;
     my $root = $self->url_root;
     $root =~ s{^/}{}g;
     my $is_dated_path = qr{^/?$root/?(\d{4})/(\d{2})/(\d{2})/};

--- a/lib/Statocles/Command/build.pm
+++ b/lib/Statocles/Command/build.pm
@@ -12,6 +12,10 @@ sub run {
         'base_url|base=s',
     );
 
+    if ($build_opt{date}) {
+      $self->site->build_date($build_opt{date});
+    }
+
     my $path = Path::Tiny->new( $argv[0] // $self->site->store->path->child( '.statocles', 'build' ) );
     $path->mkpath;
 

--- a/lib/Statocles/Site.pm
+++ b/lib/Statocles/Site.pm
@@ -13,6 +13,7 @@ use Statocles::Page::Document;
 use Statocles::Util qw( derp );
 use Statocles::Store;
 use List::UtilsBy qw( uniq_by );
+use DateTime::Moonpig;
 
 =attr store
 
@@ -414,6 +415,27 @@ has _pages => (
     lazy => 1,
     predicate => 'has_pages',
     clearer => 'clear_pages',
+);
+
+=attr build_date
+
+    ---
+    build_date: 2015-03-27
+    build_date: 2015-03-27 12:04:00
+    ---
+
+The date/time of the current build of the site. This is usually set by a build
+(or related) command. Defaults to the current date.
+
+Should be in C<YYYY-MM-DD> or C<YYYY-MM-DD HH:MM:SS> format.
+
+=cut
+
+has build_date => (
+    is => 'rw',
+    isa => DateTimeObj,
+    coerce => DateTimeObj->coercion,
+    default => sub { DateTime::Moonpig->now( time_zone => 'local' )->ymd },
 );
 
 =method BUILD


### PR DESCRIPTION
Before this commit any functionality that depended on knowing the build
date (which is possibly overridden by the command line) would need to
have the date passed in to it. With this change the site now knows what
the build date is and is therefore accessible by anything with access to
the site object.