### PR TITLE
Patch: 'Older' and 'Newer' buttons on the blog are always absolute links

### DIFF
--- a/lib/Statocles/Page/Document.pm
+++ b/lib/Statocles/Page/Document.pm
@@ -283,7 +283,7 @@ has next => (
     lazy => 1,
     isa => PagePath|Undef,
     coerce => PagePath->coercion,
-    default => sub { $_[0]->_page_path('next_page') },
+    default => sub { my $p = $_[0]->_page_path('next_page'); $p && $p !~ /^\// ? "/$p" : $p },
 );
 
 =attr prev
@@ -298,7 +298,7 @@ has prev => (
     lazy => 1,
     isa => PagePath|Undef,
     coerce => PagePath->coercion,
-    default => sub { $_[0]->_page_path('prev_page') },
+    default => sub { my $p = $_[0]->_page_path('prev_page'); $p && $p !~ /^\// ? "/$p" : $p },
 );
 
 sub _page_path {


### PR DESCRIPTION
I think the flow goes like this now:
- the blog theme calls methods `prev` and `next` to create the "Older" and "Newer" buttons
- this is earlier populated after working out what the previous page and the next page are, by the blog app
- the objects are nice `Mojo::Path`s coerced to a string, gotten from nice `Statocles::Document` objects, and they represent the right things throughout the application but it kind of breaks down in the way the application uses them.

After some bisecting I've found this got broken in the commit f7c8d5b98, which it has some changes to `Statocles::Site::_fix_internal_links` but I can't quite see what happened.

I've found this because the link checker complained about the links being broken - and it speaks to the quality of this patch that the link checker still complains about stuff - but you might prefer to have it rather than not