### PR TITLE
Posts where status is set to draft don't show up in a blog, or a list of tags

### DIFF
--- a/lib/Statocles/App/Blog.pm
+++ b/lib/Statocles/App/Blog.pm
@@ -26,7 +26,7 @@ sub _routify {
 sub register {
     my ( $self, $app, $conf ) = @_;
     my $route = _routify( $app, delete $conf->{route} // $conf->{base_url} );
-    my $filter = { %{ delete $conf->{filter} // {} }, date => { '!=' => undef } };
+    my $filter = { %{ delete $conf->{filter} // {} }, date => { '!=' => undef }, status => { '!=' => 'draft'}};
     push @{$app->renderer->classes}, __PACKAGE__, 'Statocles::App::List';
     my $index_route = $route->get( '<page:num>' )->to(
         'yancy#list',


### PR DESCRIPTION
I've been thinking about the boolean flag alternative to `status => published|draft`, eg.
```
draft: true
```
but `draft: false` translates to `{draft => 'false'} in current `YAML.pm` so steering people towards using YAML booleans will expose them to this bug.

Posts without a status will be correctly included but produce a warning, until https://github.com/preaction/Yancy/pull/71.