### PR TITLE
Render tags in the packaged themes

### DIFF
--- a/lib/Statocles/resources/theme/bootstrap/blog.html.ep
+++ b/lib/Statocles/resources/theme/bootstrap/blog.html.ep
@@ -7,6 +7,13 @@
     <header>
         <h1><a href="<%= url_for( "/$item->{path}" ) %>"><%== $item->{title} %></a></h1>
 
+        % if ( $item->{tags} ) {
+        <p class="tags">Tags:
+            % for my $tag ( @{$item->{tags}} ) {
+                <a href="<%= url_for( "/tag/$tag") %>" rel="tag"><%== $tag %></a>
+            % }
+        </p>
+        % }
         <aside>
             <p><time datetime="<%= strftime('%Y-%m-%d', $item->{date}) %>">
                 Posted on <%= strftime('%Y-%m-%d', $item->{date}) %>

--- a/lib/Statocles/resources/theme/default/blog.html.ep
+++ b/lib/Statocles/resources/theme/default/blog.html.ep
@@ -20,6 +20,13 @@
             <a data-disqus-identifier="<%= url_for( "/$item->{path}" ) %>" href="<%= url_for( "/$item->{path}" ) %>#disqus_thread">0 comments</a>
             % }
         </aside>
+        % if ( $item->{tags} ) {
+        <p class="tags">Tags:
+            % for my $tag ( @{$item->{tags}} ) {
+                <a href="<%= url_for( "/tag/$tag") %>" rel="tag"><%== $tag %></a>
+            % }
+        </p>
+        % }
     </header>
 
     % my $sections = sectionize( $item->{html} );


### PR DESCRIPTION
Looks the same as in v2 but hidden behind an extra if - tags are not fully supported yet (can't add them through Yancy UI) and anyway, better write nothing than Tags: <empty> for a post without tags.