### PR TITLE
Remove stuff from default CSS

### DIFF
--- a/lib/Statocles/resources/theme/default/css/statocles-default.css
+++ b/lib/Statocles/resources/theme/default/css/statocles-default.css
@@ -152,7 +152,6 @@ img.u-pull-left, img.u-pull-right {
     overflow: hidden;
     border-bottom: 1px solid #bbb;
     color: #777;
-    background-color: white;
     margin-bottom: 1em;
 }
 
@@ -249,27 +248,6 @@ footer .tagline {
     font-size: smaller;
     line-height: 1.3;
     text-align: right;
-}
-
-/** Crumbtrail widget */
-
-.crumbtrail ul {
-    display: inline-block;
-    list-style: none;
-    margin: 0;
-}
-
-.crumbtrail li {
-    display: inline-block;
-}
-
-.crumbtrail li::before {
-    content: '::';
-    display: inline-block;
-}
-
-.crumbtrail li:first-child::before {
-    content: '';
 }
 
 /************************************************


### PR DESCRIPTION
I tried to change background when inheriting from a default theme and the navbar was still white. So remove the white navbar background from the default theme -  it's white anyway.

Remove the crumbtrail CSS - it was for Perldoc, not yet in v2.

