### PR TITLE
Add options for optional include directories

### DIFF
--- a/bin/statocles
+++ b/bin/statocles
@@ -30,7 +30,7 @@ __END__
 
 =head1 SYNOPSIS
 
-    statocles [-v] [--config <file>] [--include <dir>] [--site <site>] <command>
+    statocles [-v] [--config <file>] [--include <dir>] [--lib] [--site <site>] <command>
     statocles -h|--help
     statocles -v|--version
 
@@ -71,6 +71,10 @@ C<site>.
 =head2 include <dir>
 
 The directory to search for includes. It works by prepending the path to C<@INC>. If specified multiple times, it prepends the directories in the same order as written on the command line.
+
+=head2 lib
+
+Shortcut for C<--include lib>.
 
 =head2 -p <port>
 

--- a/bin/statocles
+++ b/bin/statocles
@@ -30,7 +30,7 @@ __END__
 
 =head1 SYNOPSIS
 
-    statocles [-v] [--config <file>] [--site <site>] <command>
+    statocles [-v] [--config <file>] [--include <dir>] [--site <site>] <command>
     statocles -h|--help
     statocles -v|--version
 
@@ -67,6 +67,10 @@ The configuration file is a L<Beam::Wire> container file.
 
 The site to use, which is the name of an object in the config file. Defaults to
 C<site>.
+
+=head2 include <dir>
+
+The directory to search for includes. It works by prepending the path to C<@INC>. If specified multiple times, it prepends the directories in the same order as written on the command line.
 
 =head2 -p <port>
 

--- a/lib/Statocles.pm
+++ b/lib/Statocles.pm
@@ -46,6 +46,7 @@ sub run {
         'version',
         'verbose|v+',
         'include|I:s@',
+        'lib|l',
     );
     return pod2usage(0) if $opt{help};
 
@@ -54,6 +55,10 @@ sub run {
         require POSIX;
         say "Locale: " . POSIX::setlocale( POSIX::LC_CTYPE );
         return 0;
+    }
+
+    if ( $opt{lib} ) {
+        unshift @{ $opt{include} }, 'lib';
     }
 
     if ( $opt{include} ) {

--- a/lib/Statocles.pm
+++ b/lib/Statocles.pm
@@ -45,6 +45,7 @@ sub run {
         'help|h',
         'version',
         'verbose|v+',
+        'include|I:s@',
     );
     return pod2usage(0) if $opt{help};
 
@@ -53,6 +54,10 @@ sub run {
         require POSIX;
         say "Locale: " . POSIX::setlocale( POSIX::LC_CTYPE );
         return 0;
+    }
+
+    if ( $opt{include} ) {
+        unshift @INC, @{ $opt{include} };
     }
 
     my $method = shift @argv;


### PR DESCRIPTION
This PR adds support for an optional `--include` CLI option, as well as a related `--lib` option for convenience.

Context: when Statocles functionality needs to be extended e.g. via custom plugins, then those modules somehow should be discoverable via `@INC`.

One approach could be to manipulate the contents of the `PERL5LIB` environment variable, but that often felt like a workaround, especially if this is only needed in a few selected projects instead of globally.

I decided to play around with adding a command line option for that, and since I always had to include `./lib` only, I added a convenience wrapper for that use case too.

Please review the changes, and let me know if this sounds useful, and if yes, whether I should change anything before merging :)