### PR TITLE
Fix compatibility with Mojolicious 9 and YAML 1.30

### DIFF
--- a/lib/Statocles/Command/daemon.pm
+++ b/lib/Statocles/Command/daemon.pm
@@ -166,7 +166,7 @@ sub run {
 
         my $serve_static = sub {
             my ( $c ) = @_;
-            my $path = Mojo::Path->new( $c->stash->{path} );
+            my $path = Mojo::Path->new( $c->stash->{fallback} );
 
             # Taint check the path, just in case someone uses this "dev" tool to
             # serve real content
@@ -177,7 +177,7 @@ sub run {
             if ( !$asset ) {
                 if ( $path =~ m{/$} ) {
                     # Check for index.html
-                    $path = Mojo::Path->new( $c->stash->{path} . "/index.html" );
+                    $path = Mojo::Path->new( $c->stash->{fallback} . "/index.html" );
                     $asset = $c->app->static->file( $path );
                 }
                 elsif ( $store->path->child( $path )->is_dir ) {
@@ -198,10 +198,10 @@ sub run {
                 my ( $c ) = @_;
                 $c->redirect_to( $base );
             } );
-            $self->routes->get( $base . '/*path' )->to( path => 'index.html', cb => $serve_static );
+            $self->routes->get( $base . '/*fallback' )->to( fallback => 'index.html', cb => $serve_static );
         }
         else {
-            $self->routes->get( '/*path' )->to( path => 'index.html', cb => $serve_static );
+            $self->routes->get( '/*fallback' )->to( fallback => 'index.html', cb => $serve_static );
         }
 
     }

--- a/lib/Statocles/Test.pm
+++ b/lib/Statocles/Test.pm
@@ -328,6 +328,7 @@ sub build_temp_site {
     };
 
     my $config_fn = $tmp->child( 'site.yml' );
+    $YAML::Stringify = 1;
     YAML::DumpFile( $config_fn, $config );
     return ( $tmp, $config_fn, $config );
 }

--- a/t/theme/check.t
+++ b/t/theme/check.t
@@ -384,11 +384,11 @@ sub test_layout_content {
     };
 
     subtest 'site stylesheet and script links get added' => sub {
-        if ( ok $elem = $dom->at( 'link[href=/theme/css/site-style.css]', 'site stylesheet exists' ) ) {
+        if ( ok $elem = $dom->at( 'link[href=/theme/css/site-style.css]' ), 'site stylesheet exists' ) {
             is $elem->attr( 'rel' ), 'stylesheet';
             is $elem->attr( 'type' ), 'text/css';
         }
-        if ( ok $elem = $dom->at( 'script[src=/theme/js/site-script.js]', 'site script exists' ) ) {
+        if ( ok $elem = $dom->at( 'script[src=/theme/js/site-script.js]' ), 'site script exists' ) {
             ok !$elem->text, 'no text inside';
         }
         if ( ok my $elems = $dom->find( 'head script' )->grep( 'text' ) ) {
@@ -399,20 +399,20 @@ sub test_layout_content {
     };
 
     subtest 'document stylesheet links get added in the layout' => sub {
-        if ( ok $elem = $dom->at( 'link[href=/theme/css/special.css]', 'document stylesheet exists' ) ) {
+        if ( ok $elem = $dom->at( 'link[href=/theme/css/special.css]' ), 'document stylesheet exists' ) {
             is $elem->attr( 'rel' ), 'stylesheet';
             is $elem->attr( 'type' ), 'text/css';
         }
     };
 
     subtest 'document script links get added in the layout' => sub {
-        if ( ok $elem = $dom->at( 'script[src=/theme/js/special.js]', 'document script exists' ) ) {
+        if ( ok $elem = $dom->at( 'script[src=/theme/js/special.js]' ), 'document script exists' ) {
             ok !$elem->text, 'no text inside';
         }
     };
 
     subtest 'shortcut icon' => sub {
-        if ( ok $elem = $dom->at( 'link[rel="shortcut icon"]', 'shortcut icon link exists' ) ) {
+        if ( ok $elem = $dom->at( 'link[rel="shortcut icon"]' ), 'shortcut icon link exists' ) {
             is $elem->attr( 'href' ), '/favicon.ico';
         }
     };


### PR DESCRIPTION
There are three commits in this pull request.

- lib/Statocles/Command/daemon.pm: Taken from Yancy for compatibility with Mojolicious 9.
- t/theme/check.t: Several parens are in the wrong places and warnings are output.
- lib/Statocles/Test.pm: If $YAML::Stringify is not set to 1, the serialized Path::Tiny objects break the site.yml so that some tests fail.

Tested on Linux with Perl 5.32.1 and the most recent versions of all required modules.