### PR TITLE
Suppress git warning about initial branch name

### DIFF
--- a/lib/Statocles/Command/create.pm
+++ b/lib/Statocles/Command/create.pm
@@ -147,7 +147,7 @@ sub create_site {
         # Running init more than once is apparently completely safe, so we don't
         # even have to check before we run it
         chdir $root;
-        Git::Repository->run( 'init' );
+        Git::Repository->run( 'init', '-q' );
         chdir $cwd;
         $root->child( '.gitignore' )->append( "\n.statocles\n" );
     }

--- a/t/command/create.t
+++ b/t/command/create.t
@@ -314,7 +314,7 @@ subtest 'git deploy' => sub {
         my $tmp = tempdir;
         chdir $tmp;
 
-        Git::Repository->run( 'init' );
+        Git::Repository->run( 'init', '-q' );
         $tmp->child( '.gitignore' )->spew( "some\n\nexisting\npaths\n" );
 
         my $in = $SHARE_DIR->child( qw( create basic_blog_in.txt ) )->openr_utf8;

--- a/t/deploy/git.t
+++ b/t/deploy/git.t
@@ -390,7 +390,7 @@ done_testing;
 sub make_git {
     my ( $dir, %args ) = @_;
 
-    Git::Repository->run( "init", ( $args{bare} ? ( '--bare' ) : () ), "$dir" );
+    Git::Repository->run( "init", ( $args{bare} ? ( '--bare' ) : () ), '-b', 'master', "$dir" );
 
     my $git = Git::Repository->new( work_tree => "$dir" );
 


### PR DESCRIPTION
This commit silences the below warning from recent Git releases. The tests work for me with the changes from this pull request and from #602.

    hint: Using 'master' as the name for the initial branch. This default branch name
    hint: is subject to change. To configure the initial branch name to use in all
    hint: of your new repositories, which will suppress this warning, call:
    hint: 
    hint:   git config --global init.defaultBranch <name>
