### PR TITLE
Fix the Git tests

### DIFF
--- a/t/deploy/git.t
+++ b/t/deploy/git.t
@@ -166,7 +166,8 @@ subtest 'deploy with submodules and ignored files' => sub {
 
     # Git::Repository sets the "GIT_WORK_TREE" envvar, which makes most
     # submodule commands fail, so we have to unset it.
-    _git_run( $git, submodule => add => "file://$submoduledir",
+    _git_run( $git, qw( -c protocol.file.allow=always ),
+        submodule => add => "file://$submoduledir",
         { env => { GIT_WORK_TREE => undef } }
     );
     _git_run( $git, commit => '-m' => 'add submodule' );

--- a/t/deploy/git.t
+++ b/t/deploy/git.t
@@ -391,7 +391,16 @@ done_testing;
 sub make_git {
     my ( $dir, %args ) = @_;
 
-    Git::Repository->run( "init", ( $args{bare} ? ( '--bare' ) : () ), '-b', 'master', "$dir" );
+    my $git_version = Statocles::Deploy::Git->_git_version;
+
+    my @options;
+    if ($args{bare}) {
+        push @options, '--bare';
+    }
+    if ($git_version >= 2.028000) {
+        push @options, '-b', 'master';
+    }
+    Git::Repository->run( "init", @options, "$dir" );
 
     my $git = Git::Repository->new( work_tree => "$dir" );
 


### PR DESCRIPTION
This pull request updates `t/deploy/git.t`. The option `-b master` is only passed to `git init` if Git is recent enough. This change fixes #606. A second commit fixes an issue with Git 2.38.1 and newer, which is also present in the [Git::Repository](https://github.com/book/Git-Repository/pull/22) test suite. Tested on CentOS 7, Rocky Linux 8, Fedora 38 and Ubuntu 20.04.