### PR TITLE
Add -raw to the include example

### DIFF
--- a/lib/Statocles/Plugin/Highlight.pm
+++ b/lib/Statocles/Plugin/Highlight.pm
@@ -87,7 +87,7 @@ To highlight a block of code, use C<begin>/C<end>:
 
 To highlight an included file, use the L<include helper|Statocles::Template/include>:
 
-    %= highlight Perl => include 'test.pl'
+    %= highlight Perl => include -raw => 'test.pl'
 
 The highlight function adds both C<pre> and C<code> tags.
 


### PR DESCRIPTION
This pull request updates an example in `lib/Statocles/Plugin/Highlight.pm`. The include option `-raw` ensures that source code passages that look like Mojo::Template tags aren't interpreted by Statocles. Might be related to #600.