### PR TITLE
Update website link

### DIFF
--- a/lib/Statocles/Help.pod
+++ b/lib/Statocles/Help.pod
@@ -232,6 +232,6 @@ Be patient, it's a slow channel.
 
 =head1 SEE ALSO
 
-For news and documentation, L<visit the Statocles website at
-http:E<sol>E<sol>preaction.me<sol>statocles|http://preaction.me/statocles>.
+For news and documentation, L<visit the Statocles
+website|http://preaction.me/statocles>.
 


### PR DESCRIPTION
This pull request changes the website link on the help page. Fixes #598. With this change, the HTML output contains the text "For news and documentation, [visit the Statocles website](http://preaction.me/statocles)". The manual page, on the other hand, shows the address:

```
SEE ALSO
    For news and documentation, visit the Statocles website
    <http://preaction.me/statocles>.
```